### PR TITLE
Rename and remove deprecated functions in the cluster API

### DIFF
--- a/include/valkey/valkeycluster.h
+++ b/include/valkey/valkeycluster.h
@@ -172,10 +172,6 @@ void valkeyClusterFree(valkeyClusterContext *cc);
 /* Configuration options */
 int valkeyClusterSetOptionAddNode(valkeyClusterContext *cc, const char *addr);
 int valkeyClusterSetOptionAddNodes(valkeyClusterContext *cc, const char *addrs);
-/* Deprecated function, option has no effect. */
-int valkeyClusterSetOptionConnectBlock(valkeyClusterContext *cc);
-/* Deprecated function, option has no effect. */
-int valkeyClusterSetOptionConnectNonBlock(valkeyClusterContext *cc);
 int valkeyClusterSetOptionUsername(valkeyClusterContext *cc,
                                    const char *username);
 int valkeyClusterSetOptionPassword(valkeyClusterContext *cc,
@@ -188,9 +184,6 @@ int valkeyClusterSetOptionTimeout(valkeyClusterContext *cc,
                                   const struct timeval tv);
 int valkeyClusterSetOptionMaxRetry(valkeyClusterContext *cc,
                                    int max_retry_count);
-/* Deprecated function, replaced with valkeyClusterSetOptionMaxRetry() */
-void valkeyClusterSetMaxRedirect(valkeyClusterContext *cc,
-                                 int max_redirect_count);
 /* A hook for connect and reconnect attempts, e.g. for applying additional
  * socket options. This is called just after connect, before TLS handshake and
  * Valkey authentication.

--- a/include/valkey/valkeycluster.h
+++ b/include/valkey/valkeycluster.h
@@ -66,7 +66,6 @@
 extern "C" {
 #endif
 
-struct dict;
 struct hilist;
 struct valkeyClusterAsyncContext;
 
@@ -263,10 +262,6 @@ int valkeyClusterUpdateSlotmap(valkeyClusterContext *cc);
 /* Internal functions */
 valkeyContext *ctx_get_by_node(valkeyClusterContext *cc,
                                valkeyClusterNode *node);
-struct dict *parse_cluster_nodes(valkeyClusterContext *cc, char *str,
-                                 int str_len, int flags);
-struct dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply,
-                                 int flags);
 
 /*
  * Asynchronous API

--- a/include/valkey/valkeycluster.h
+++ b/include/valkey/valkeycluster.h
@@ -259,9 +259,10 @@ void valkeyClusterReset(valkeyClusterContext *cc);
 /* Update the slotmap by querying any node. */
 int valkeyClusterUpdateSlotmap(valkeyClusterContext *cc);
 
-/* Internal functions */
-valkeyContext *ctx_get_by_node(valkeyClusterContext *cc,
-                               valkeyClusterNode *node);
+/* Get the valkeyContext used for communication with a given node.
+ * Connects or reconnects to the node if necessary. */
+valkeyContext *valkeyClusterGetValkeyContext(valkeyClusterContext *cc,
+                                             valkeyClusterNode *node);
 
 /*
  * Asynchronous API
@@ -316,9 +317,10 @@ int valkeyClusterAsyncFormattedCommandToNode(valkeyClusterAsyncContext *acc,
                                              void *privdata, char *cmd,
                                              int len);
 
-/* Internal functions */
-valkeyAsyncContext *actx_get_by_node(valkeyClusterAsyncContext *acc,
-                                     valkeyClusterNode *node);
+/* Get the valkeyAsyncContext used for communication with a given node.
+ * Connects or reconnects to the node if necessary. */
+valkeyAsyncContext *valkeyClusterGetValkeyAsyncContext(valkeyClusterAsyncContext *acc,
+                                                       valkeyClusterNode *node);
 
 /* Cluster node iterator functions */
 void valkeyClusterInitNodeIterator(valkeyClusterNodeIterator *iter,

--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -674,8 +674,8 @@ oom:
 /**
  * Parse the "cluster slots" command reply to nodes dict.
  */
-dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply,
-                          int flags) {
+static dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply,
+                                 int flags) {
     int ret;
     cluster_slot *slot = NULL;
     dict *nodes = NULL;
@@ -866,8 +866,8 @@ error:
 /**
  * Parse the "cluster nodes" command reply to nodes dict.
  */
-dict *parse_cluster_nodes(valkeyClusterContext *cc, char *str, int str_len,
-                          int flags) {
+static dict *parse_cluster_nodes(valkeyClusterContext *cc, char *str, int str_len,
+                                 int flags) {
     int ret;
     dict *nodes = NULL;
     dict *nodes_name = NULL;

--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -1601,22 +1601,6 @@ int valkeyClusterSetOptionAddNodes(valkeyClusterContext *cc,
     return VALKEY_OK;
 }
 
-/* Deprecated function, option has no effect. */
-int valkeyClusterSetOptionConnectBlock(valkeyClusterContext *cc) {
-    if (cc == NULL) {
-        return VALKEY_ERR;
-    }
-    return VALKEY_OK;
-}
-
-/* Deprecated function, option has no effect. */
-int valkeyClusterSetOptionConnectNonBlock(valkeyClusterContext *cc) {
-    if (cc == NULL) {
-        return VALKEY_ERR;
-    }
-    return VALKEY_OK;
-}
-
 /**
  * Configure a username used during authentication, see
  * the Valkey AUTH command.
@@ -2273,16 +2257,6 @@ static int prepareCommand(valkeyClusterContext *cc, struct cmd *command) {
     }
     command->slot_num = keyHashSlot(command->key.start, command->key.len);
     return VALKEY_OK;
-}
-
-/* Deprecated function, replaced with valkeyClusterSetOptionMaxRetry() */
-void valkeyClusterSetMaxRedirect(valkeyClusterContext *cc,
-                                 int max_retry_count) {
-    if (cc == NULL || max_retry_count <= 0) {
-        return;
-    }
-
-    cc->max_retry_count = max_retry_count;
 }
 
 int valkeyClusterSetConnectCallback(valkeyClusterContext *cc,

--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -1788,8 +1788,8 @@ int valkeyClusterConnect2(valkeyClusterContext *cc) {
     return valkeyClusterUpdateSlotmap(cc);
 }
 
-valkeyContext *ctx_get_by_node(valkeyClusterContext *cc,
-                               valkeyClusterNode *node) {
+valkeyContext *valkeyClusterGetValkeyContext(valkeyClusterContext *cc,
+                                             valkeyClusterNode *node) {
     valkeyContext *c = NULL;
     if (node == NULL) {
         return NULL;
@@ -1901,7 +1901,7 @@ static int valkeyClusterAppendCommandInternal(valkeyClusterContext *cc,
         return VALKEY_ERR;
     }
 
-    c = ctx_get_by_node(cc, node);
+    c = valkeyClusterGetValkeyContext(cc, node);
     if (c == NULL) {
         return VALKEY_ERR;
     } else if (c->err) {
@@ -2066,7 +2066,7 @@ retry:
         }
     }
 
-    c = ctx_get_by_node(cc, node);
+    c = valkeyClusterGetValkeyContext(cc, node);
     if (c == NULL || c->err) {
         /* Failed to connect. Maybe there was a failover and this node is gone.
          * Update slotmap to find out. */
@@ -2078,7 +2078,7 @@ retry:
         if (node == NULL) {
             goto error;
         }
-        c = ctx_get_by_node(cc, node);
+        c = valkeyClusterGetValkeyContext(cc, node);
         if (c == NULL) {
             goto error;
         } else if (c->err) {
@@ -2154,7 +2154,7 @@ ask_retry:
                 }
             }
 
-            c = ctx_get_by_node(cc, node);
+            c = valkeyClusterGetValkeyContext(cc, node);
             if (c == NULL) {
                 goto error;
             } else if (c->err) {
@@ -2174,7 +2174,7 @@ ask_retry:
             freeReplyObject(reply);
             reply = NULL;
 
-            c = ctx_get_by_node(cc, node);
+            c = valkeyClusterGetValkeyContext(cc, node);
             if (c == NULL) {
                 goto error;
             } else if (c->err) {
@@ -2371,7 +2371,7 @@ void *valkeyClustervCommandToNode(valkeyClusterContext *cc,
     void *reply;
     int updating_slotmap = 0;
 
-    c = ctx_get_by_node(cc, node);
+    c = valkeyClusterGetValkeyContext(cc, node);
     if (c == NULL) {
         return NULL;
     } else if (c->err) {
@@ -2550,7 +2550,7 @@ int valkeyClustervAppendCommandToNode(valkeyClusterContext *cc,
         cc->requests->free = listCommandFree;
     }
 
-    c = ctx_get_by_node(cc, node);
+    c = valkeyClusterGetValkeyContext(cc, node);
     if (c == NULL) {
         return VALKEY_ERR;
     } else if (c->err) {
@@ -2653,7 +2653,7 @@ static int valkeyClusterSendAll(valkeyClusterContext *cc) {
             continue;
         }
 
-        c = ctx_get_by_node(cc, node);
+        c = valkeyClusterGetValkeyContext(cc, node);
         if (c == NULL) {
             continue;
         }
@@ -2880,8 +2880,9 @@ static void unlinkAsyncContextAndNode(void *data) {
     }
 }
 
-valkeyAsyncContext *actx_get_by_node(valkeyClusterAsyncContext *acc,
-                                     valkeyClusterNode *node) {
+valkeyAsyncContext *
+valkeyClusterGetValkeyAsyncContext(valkeyClusterAsyncContext *acc,
+                                   valkeyClusterNode *node) {
     valkeyAsyncContext *ac;
     int ret;
 
@@ -3168,7 +3169,7 @@ static int updateSlotMapAsync(valkeyClusterAsyncContext *acc,
         }
 
         /* Get libvalkey context, connect if needed */
-        ac = actx_get_by_node(acc, node);
+        ac = valkeyClusterGetValkeyAsyncContext(acc, node);
     }
     if (ac == NULL)
         goto error; /* Specific error already set */
@@ -3277,7 +3278,7 @@ static void valkeyClusterAsyncCallback(valkeyAsyncContext *ac, void *r,
             if (slot >= 0) {
                 cc->table[slot] = node;
             }
-            ac_retry = actx_get_by_node(acc, node);
+            ac_retry = valkeyClusterGetValkeyAsyncContext(acc, node);
 
             break;
         case CLUSTER_ERR_ASK:
@@ -3287,7 +3288,7 @@ static void valkeyClusterAsyncCallback(valkeyAsyncContext *ac, void *r,
                 goto done;
             }
 
-            ac_retry = actx_get_by_node(acc, node);
+            ac_retry = valkeyClusterGetValkeyAsyncContext(acc, node);
             if (ac_retry == NULL) {
                 /* Specific error already set */
                 goto done;
@@ -3411,7 +3412,7 @@ int valkeyClusterAsyncFormattedCommand(valkeyClusterAsyncContext *acc,
         goto error;
     }
 
-    ac = actx_get_by_node(acc, node);
+    ac = valkeyClusterGetValkeyAsyncContext(acc, node);
     if (ac == NULL) {
         /* Specific error already set */
         goto error;
@@ -3463,7 +3464,7 @@ int valkeyClusterAsyncFormattedCommandToNode(valkeyClusterAsyncContext *acc,
         return VALKEY_ERR;
     }
 
-    ac = actx_get_by_node(acc, node);
+    ac = valkeyClusterGetValkeyAsyncContext(acc, node);
     if (ac == NULL) {
         /* Specific error already set */
         return VALKEY_ERR;


### PR DESCRIPTION
Rename API functions to get a standalone context from a cluster node, which are needed to support PUB/SUB.
```
ctx_get_by_node  -> valkeyClusterGetValkeyContext
actx_get_by_node -> valkeyClusterGetValkeyAsyncContext
```
- Remove internal `parse_cluster_*` functions from the cluster API. Should not be needed by users.
- Remove deprecated functions in the cluster API.