### PR TITLE
Fully abstract valkeyContextFuncs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ SET(valkey_sources
     src/alloc.c
     src/async.c
     src/command.c
+    src/conn.c
     src/crc16.c
     src/dict.c
     src/net.c

--- a/include/valkey/valkey.h
+++ b/include/valkey/valkey.h
@@ -147,7 +147,9 @@ void valkeyFreeSdsCommand(sds cmd);
 enum valkeyConnectionType {
     VALKEY_CONN_TCP,
     VALKEY_CONN_UNIX,
-    VALKEY_CONN_USERFD
+    VALKEY_CONN_USERFD,
+
+    VALKEY_CONN_MAX
 };
 
 struct valkeySsl;
@@ -239,6 +241,7 @@ typedef struct {
     } while(0)
 
 typedef struct valkeyContextFuncs {
+    int (*connect)(struct valkeyContext *, const valkeyOptions *);
     void (*close)(struct valkeyContext *);
     void (*free_privctx)(void *);
     void (*async_read)(struct valkeyAsyncContext *);
@@ -250,6 +253,7 @@ typedef struct valkeyContextFuncs {
      * recoverable error, they should return 0. */
     ssize_t (*read)(struct valkeyContext *, char *, size_t);
     ssize_t (*write)(struct valkeyContext *);
+    int (*set_timeout)(struct valkeyContext *, const struct timeval);
 } valkeyContextFuncs;
 
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -1,9 +1,5 @@
-/* Extracted from anet.c to work properly with Hiredis error reporting.
- *
- * Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
- * Copyright (c) 2010-2014, Pieter Noordhuis <pcnoordhuis at gmail dot com>
- * Copyright (c) 2015, Matt Stancliff <matt at genges dot com>,
- *                     Jan-Erik Rediger <janerik at fnordig dot com>
+/*
+ * Copyright (c) 2024, zhenwei pi <pizhenwei@bytedance.com>
  *
  * All rights reserved.
  *
@@ -15,9 +11,9 @@
  *   * Redistributions in binary form must reproduce the above copyright
  *     notice, this list of conditions and the following disclaimer in the
  *     documentation and/or other materials provided with the distribution.
- *   * Neither the name of Redis nor the names of its contributors may be used
- *     to endorse or promote products derived from this software without
- *     specific prior written permission.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -32,20 +28,34 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef VALKEY_NET_H
-#define VALKEY_NET_H
+#include "valkey_private.h"
 
-#include "valkey.h"
+#include <assert.h>
 
-void valkeyNetClose(valkeyContext *c);
+static valkeyContextFuncs *_valkeyContextFuncs[VALKEY_CONN_MAX];
 
-int valkeyCheckSocketError(valkeyContext *c);
-int valkeyTcpSetTimeout(valkeyContext *c, const struct timeval tv);
-int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options);
-int valkeyKeepAlive(valkeyContext *c, int interval);
-int valkeyCheckConnectDone(valkeyContext *c, int *completed);
+int valkeyContextRegisterFuncs(valkeyContextFuncs *funcs, enum valkeyConnectionType type) {
+    assert(type < VALKEY_CONN_MAX);
+    assert(!_valkeyContextFuncs[type]);
 
-int valkeySetTcpNoDelay(valkeyContext *c);
-int valkeyContextSetTcpUserTimeout(valkeyContext *c, unsigned int timeout);
+    _valkeyContextFuncs[type] = funcs;
+    return VALKEY_OK;
+}
 
-#endif
+void valkeyContextSetFuncs(valkeyContext *c) {
+    valkeyContextFuncs *funcs;
+    static int initialized;
+
+    if (!initialized) {
+        initialized = 1;
+        valkeyContextRegisterTcpFuncs();
+        valkeyContextRegisterUnixFuncs();
+        valkeyContextRegisterUserfdFuncs();
+    }
+
+    assert(c->connection_type < VALKEY_CONN_MAX);
+    assert(!c->funcs);
+    assert(funcs = _valkeyContextFuncs[c->connection_type]);
+
+    c->funcs = funcs;
+}

--- a/src/ssl.c
+++ b/src/ssl.c
@@ -609,11 +609,13 @@ static void valkeySSLAsyncWrite(valkeyAsyncContext *ac) {
 }
 
 static valkeyContextFuncs valkeyContextSSLFuncs = {
+    .connect = valkeyContextConnectTcp,
     .close = valkeyNetClose,
     .free_privctx = valkeySSLFree,
     .async_read = valkeySSLAsyncRead,
     .async_write = valkeySSLAsyncWrite,
     .read = valkeySSLRead,
-    .write = valkeySSLWrite
+    .write = valkeySSLWrite,
+    .set_timeout = valkeyTcpSetTimeout
 };
 

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -760,13 +760,13 @@ int valkeyReconnect(valkeyContext *c) {
     c->err = 0;
     memset(c->errstr, '\0', strlen(c->errstr));
 
+    if (c->funcs && c->funcs->close) {
+        c->funcs->close(c);
+    }
+
     if (c->privctx && c->funcs->free_privctx) {
         c->funcs->free_privctx(c->privctx);
         c->privctx = NULL;
-    }
-
-    if (c->funcs && c->funcs->close) {
-        c->funcs->close(c);
     }
 
     sdsfree(c->obuf);

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -42,17 +42,7 @@
 #include "valkey_private.h"
 #include "net.h"
 #include "sds.h"
-#include "async.h"
 #include "win32.h"
-
-static valkeyContextFuncs valkeyContextDefaultFuncs = {
-    .close = valkeyNetClose,
-    .free_privctx = NULL,
-    .async_read = valkeyAsyncRead,
-    .async_write = valkeyAsyncWrite,
-    .read = valkeyNetRead,
-    .write = valkeyNetWrite
-};
 
 static valkeyReply *createReplyObject(int type);
 static void *createStringObject(const valkeyReadTask *task, char *str, size_t len);
@@ -718,8 +708,6 @@ static valkeyContext *valkeyContextInit(void) {
     if (c == NULL)
         return NULL;
 
-    c->funcs = &valkeyContextDefaultFuncs;
-
     c->obuf = sdsempty();
     c->reader = valkeyReaderCreate();
     c->fd = VALKEY_INVALID_FD;
@@ -767,6 +755,8 @@ valkeyFD valkeyFreeKeepFd(valkeyContext *c) {
 }
 
 int valkeyReconnect(valkeyContext *c) {
+    valkeyOptions options = { .connect_timeout = c->connect_timeout };
+
     c->err = 0;
     memset(c->errstr, '\0', strlen(c->errstr));
 
@@ -792,10 +782,11 @@ int valkeyReconnect(valkeyContext *c) {
 
     int ret = VALKEY_ERR;
     if (c->connection_type == VALKEY_CONN_TCP) {
-        ret = valkeyContextConnectBindTcp(c, c->tcp.host, c->tcp.port,
-               c->connect_timeout, c->tcp.source_addr);
+        options.endpoint.tcp.ip = c->tcp.host;
+        options.endpoint.tcp.source_addr = c->tcp.source_addr;
+        options.endpoint.tcp.port = c->tcp.port;
     } else if (c->connection_type == VALKEY_CONN_UNIX) {
-        ret = valkeyContextConnectUnix(c, c->unix_sock.path, c->connect_timeout);
+        options.endpoint.unix_socket = c->unix_sock.path;
     } else {
         /* Something bad happened here and shouldn't have. There isn't
            enough information in the context to reconnect. */
@@ -803,15 +794,23 @@ int valkeyReconnect(valkeyContext *c) {
         ret = VALKEY_ERR;
     }
 
+    ret = c->funcs->connect(c, &options);
+
     if (c->command_timeout != NULL && (c->flags & VALKEY_BLOCK) && c->fd != VALKEY_INVALID_FD) {
-        valkeyContextSetTimeout(c, *c->command_timeout);
+        c->funcs->set_timeout(c, *c->command_timeout);
     }
 
     return ret;
 }
 
 valkeyContext *valkeyConnectWithOptions(const valkeyOptions *options) {
-    valkeyContext *c = valkeyContextInit();
+    valkeyContext *c;
+
+    if (options->type >= VALKEY_CONN_MAX) {
+        return NULL;
+    }
+
+    c = valkeyContextInit();
     if (c == NULL) {
         return NULL;
     }
@@ -850,25 +849,13 @@ valkeyContext *valkeyConnectWithOptions(const valkeyOptions *options) {
         return c;
     }
 
-    if (options->type == VALKEY_CONN_TCP) {
-        valkeyContextConnectBindTcp(c, options->endpoint.tcp.ip,
-                                   options->endpoint.tcp.port, options->connect_timeout,
-                                   options->endpoint.tcp.source_addr);
-    } else if (options->type == VALKEY_CONN_UNIX) {
-        valkeyContextConnectUnix(c, options->endpoint.unix_socket,
-                                options->connect_timeout);
-    } else if (options->type == VALKEY_CONN_USERFD) {
-        c->fd = options->endpoint.fd;
-        c->flags |= VALKEY_CONNECTED;
-    } else {
-        valkeyFree(c);
-        return NULL;
-    }
-
+    c->connection_type = options->type;
+    valkeyContextSetFuncs(c);
+    c->funcs->connect(c, options);
     if (c->err == 0 && c->fd != VALKEY_INVALID_FD &&
         options->command_timeout != NULL && (c->flags & VALKEY_BLOCK))
     {
-        valkeyContextSetTimeout(c, *options->command_timeout);
+        c->funcs->set_timeout(c, *options->command_timeout);
     }
 
     return c;
@@ -944,9 +931,15 @@ valkeyContext *valkeyConnectFd(valkeyFD fd) {
 
 /* Set read/write timeout on a blocking socket. */
 int valkeySetTimeout(valkeyContext *c, const struct timeval tv) {
-    if (c->flags & VALKEY_BLOCK)
-        return valkeyContextSetTimeout(c,tv);
-    return VALKEY_ERR;
+    if (!(c->flags & VALKEY_BLOCK))
+        return VALKEY_ERR;
+
+    if (valkeyContextUpdateCommandTimeout(c, &tv) != VALKEY_OK) {
+        valkeySetError(c, VALKEY_ERR_OOM, "Out of memory");
+        return VALKEY_ERR;
+    }
+
+    return c->funcs->set_timeout(c,tv);
 }
 
 int valkeyEnableKeepAliveWithInterval(valkeyContext *c, int interval) {

--- a/src/valkey_private.h
+++ b/src/valkey_private.h
@@ -122,4 +122,11 @@ static inline int valkeyContextUpdateCommandTimeout(valkeyContext *c,
     return VALKEY_OK;
 }
 
+int valkeyContextRegisterFuncs(valkeyContextFuncs *funcs, enum valkeyConnectionType type);
+void valkeyContextRegisterTcpFuncs(void);
+void valkeyContextRegisterUnixFuncs(void);
+void valkeyContextRegisterUserfdFuncs(void);
+
+void valkeyContextSetFuncs(valkeyContext *c);
+
 #endif  /* VALKEY_VK_PRIVATE_H */


### PR DESCRIPTION
* Move valkeyContextDefaultFuncs into net.c, then valkeyNetRead & valkeyNetWrite could be declared as static functions. async.h is no longer needed by valkey.c, that makes `valkey.c` independent from networking IO specific operations.
* Add .connect for valkeyContextFuncs, allow none-socket transport. Remove connection type related functions from `valkey.c`