### PR TITLE
windows: fix size of `ssize_t`

### DIFF
--- a/include/valkey/sds.h
+++ b/include/valkey/sds.h
@@ -35,8 +35,13 @@
 
 #define SDS_MAX_PREALLOC (1024*1024)
 #ifdef _MSC_VER
-typedef long long ssize_t;
-#define SSIZE_MAX (LLONG_MAX >> 1)
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
+#ifdef _WIN64
+#define SSIZE_MAX (_I64_MAX >> 1)
+#else
+#define SSIZE_MAX (_I32_MAX >> 1)
+#endif
 #ifndef __clang__
 #define __attribute__(x)
 #endif

--- a/include/valkey/sockcompat.h
+++ b/include/valkey/sockcompat.h
@@ -53,7 +53,8 @@
 #include <mstcpip.h>
 
 #ifdef _MSC_VER
-typedef long long ssize_t;
+#include <basetsd.h>
+typedef SSIZE_T ssize_t;
 #endif
 
 /* Emulate the parts of the BSD socket API that we need (override the winsock signatures). */

--- a/include/valkey/valkey.h
+++ b/include/valkey/valkey.h
@@ -38,8 +38,9 @@
 #ifndef _MSC_VER
 #include <sys/time.h> /* for struct timeval */
 #else
+#include <basetsd.h>
 struct timeval; /* forward declaration */
-typedef long long ssize_t;
+typedef SSIZE_T ssize_t;
 #endif
 #include <stdint.h> /* uintXX_t, etc */
 #include "sds.h" /* for sds */


### PR DESCRIPTION
Previously, `long long` was used unconditionally to define `ssize_t` on Windows. This meant it was always a 64-bit value. However, typically the size type is a 32-bit value on 32-bit machines and 64-bit value on 64-bit machines.

This didn't cause any issues until it was used on 32-bit Windows build of `libvalkey-py`. CPython defines the `ssize_t` type as well as `libvalkey`, but it defines the size to be 32 bit on 32 bit machines which caused a compilation error.

This commit changes the typedef to be `SSIZE_T` on Windows. Hence, it will be aligned with everything else.