### PR TITLE
Replace CentOS 7 with AlmaLinux 8 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,24 +42,17 @@ jobs:
       #          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
       #        run: $GITHUB_WORKSPACE/test.sh
 
-  centos7:
-    name: CentOS 7
+  almalinux8:
+    name: AlmaLinux 8
     runs-on: ubuntu-latest
-    container: centos:7
+    container: almalinux:8
     steps:
-      # CentOS 7 uses an older glibc, only v3 of actions/checkout can be used.
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Install dependencies
         run: |
-          yum -y install http://rpms.remirepo.net/enterprise/remi-release-7.rpm
-          yum -y --enablerepo=remi install redis
-          yum -y install git gcc gcc-c++ make openssl openssl-devel cmake3 valgrind libevent-devel
-
-      - name: Install Valkey
-        run: |
-          git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
-          cd valkey && BUILD_TLS=yes make install
+          dnf -y install epel-release
+          dnf -y install gcc make cmake3 openssl openssl-devel libevent-devel valgrind procps-ng valkey
 
       - name: Build using cmake
         env:


### PR DESCRIPTION
Since CentOS Linux 7 is in 'End of Life' from June 30 2024 the job has failed a while.
Replacing it with AlmaLinux 8, similar to how it was handled in [Valkey](https://github.com/valkey-io/valkey/pull/543).

Closes #42 