### PR TITLE
CI corrections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,25 +138,6 @@ jobs:
             gmake
             mkdir build && cd build && cmake .. && gmake
 
-  macos:
-    name: macOS
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Install dependencies
-        run: |
-          brew install openssl valkey
-
-      - name: Build library
-        run: USE_SSL=1 make
-
-      - name: Run tests
-        working-directory: tests
-        env:
-          TEST_SSL: 1
-        run: ./test.sh
-
   windows:
     name: Windows
     runs-on: windows-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,35 +137,3 @@ jobs:
           run: |
             gmake
             mkdir build && cd build && cmake .. && gmake
-
-  windows:
-    name: Windows
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Install dependencies
-        run: |
-          choco install -y ninja memurai-developer
-
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      - name: Build library
-        run: |
-          mkdir build && cd build
-          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
-          ninja -v
-
-      - name: Run tests
-        working-directory: ${{ github.workspace }}/build
-        run: .\tests\client_test.exe
-
-      - name: Install Cygwin Action
-        uses: cygwin/cygwin-install-action@006ad0b0946ca6d0a3ea2d4437677fa767392401 # v4
-        with:
-          packages: make git gcc-core
-
-      - name: Build in cygwin
-        env:
-          HIREDIS_PATH: ${{ github.workspace }}
-        run: |
-          make clean && make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   checkers:
     name: Run static checkers
     runs-on: ubuntu-latest
+    if: ${{ false }}  # Disabled until we have merged a formatted code base.
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run clang-format style check (.c and .h)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,15 +136,24 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      - name: Prepare
+      - name: Install dependencies
         run: |
-          choco install -y ninja
+          choco install -y ninja memurai-developer
           vcpkg install --triplet x64-windows pkgconf libevent
       - name: Build
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DDISABLE_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
           ninja -v
+      - name: Run tests
+        working-directory: build
+        run: .\tests\client_test.exe
+      - name: Install Cygwin Action
+        uses: cygwin/cygwin-install-action@006ad0b0946ca6d0a3ea2d4437677fa767392401 # v4
+        with:
+          packages: make gcc-core
+      - name: Build in Cygwin
+        run: make clean && make
 
   windows-mingw64:
     name: Windows (MinGW64)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
   ubuntu:
     name: ${{ matrix.cmake-build-type }}-build [${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }} sanitizer="${{ matrix.sanitizer }}"]
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -24,15 +24,18 @@ jobs:
         cmake-version: [3.29]
         cmake-build-type: [Release, RelWithDebInfo]
         sanitizer: ["", thread, undefined, leak, address]
+        runner: [ubuntu-22.04]
         include:
           - compiler: gcc-7
             cmake-version: 3.11
             cmake-build-type: Release
             sanitizer: ""
+            runner: ubuntu-20.04
           - compiler: clang-12
             cmake-version: 3.11
             cmake-build-type: Release
             sanitizer: ""
+            runner: ubuntu-20.04
     steps:
     - name: Prepare
       uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,15 +114,21 @@ jobs:
     name: macOS
     runs-on: macos-latest
     steps:
-      - name: Prepare
-        run: |
-          brew install cmake ninja openssl
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Build
+      - name: Install dependencies
+        run: brew install ninja valkey
+      - name: Build using CMake
         run: |
           mkdir build && cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_SSL=ON
           ninja -v
+      - name: Build using Makefile
+        run: USE_SSL=1 make
+      - name: Run tests
+        working-directory: tests
+        env:
+          TEST_SSL: 1
+        run: ./test.sh
 
   windows:
     name: Windows

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -19,6 +19,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#include <winsock2.h> /* For struct timeval */
+#endif
+
 void printReply(const valkeyReply *reply) {
     switch (reply->type) {
     case VALKEY_REPLY_ERROR:

--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -41,6 +41,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#include <winsock2.h> /* For struct timeval */
+#endif
+
 #define CMD_SIZE 256
 #define HISTORY_DEPTH 16
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,6 +1,10 @@
 #ifndef VALKEY_TEST_UTILS_H
 #define VALKEY_TEST_UTILS_H
 
+#ifdef _MSC_VER
+#include <winsock2.h> /* For struct timeval */
+#endif
+
 #define ASSERT_MSG(_x, _msg)                                                   \
     if (!(_x)) {                                                               \
         fprintf(stderr, "ERROR: %s (%s)\n", _msg, #_x);                        \


### PR DESCRIPTION
- Disable code format checker in CI
    We can enable it back when we have formatted the code base  via #53.
- Use an Ubuntu version that provides requested compiler in CI.
- Merge CI jobs for `windows`
    Includes build corrections for tests on Windows regarding missing timeval.
- Merge CI jobs for `macos`
    By only installing missing dependencies we get rid of notifications/warnings in Githubs build summary, like:
     `cmake 3.30.1 is already installed and up-to-date...`
     `openssl@3 3.3.1 is already installed and up-to-date...`
 
Together with #59 the CI should start to be green, which makes it easier to deliver changes.
The macOS with SSL tests are still a bit flaky (also seen in hiredis).