### PR TITLE
Fix possible leak when failing to send a async cluster command

### DIFF
--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -3352,7 +3352,7 @@ int valkeyClusterAsyncFormattedCommand(valkeyClusterAsyncContext *acc,
     valkeyClusterNode *node;
     valkeyAsyncContext *ac;
     struct cmd *command = NULL;
-    cluster_async_data *cad;
+    cluster_async_data *cad = NULL;
 
     if (acc == NULL) {
         return VALKEY_ERR;
@@ -3410,6 +3410,7 @@ int valkeyClusterAsyncFormattedCommand(valkeyClusterAsyncContext *acc,
 
     cad->acc = acc;
     cad->command = command;
+    command = NULL; /* Memory ownership moved. */
     cad->callback = fn;
     cad->privdata = privdata;
 
@@ -3425,6 +3426,7 @@ oom:
     // passthrough
 
 error:
+    cluster_async_data_free(cad);
     command_destroy(command);
     return VALKEY_ERR;
 }
@@ -3476,6 +3478,7 @@ int valkeyClusterAsyncFormattedCommandToNode(valkeyClusterAsyncContext *acc,
 
     cad->acc = acc;
     cad->command = command;
+    command = NULL; /* Memory ownership moved. */
     cad->callback = fn;
     cad->privdata = privdata;
     cad->retry_count = NO_RETRY;
@@ -3492,6 +3495,7 @@ oom:
     // passthrough
 
 error:
+    cluster_async_data_free(cad);
     command_destroy(command);
     return VALKEY_ERR;
 }

--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -3417,6 +3417,7 @@ int valkeyClusterAsyncFormattedCommand(valkeyClusterAsyncContext *acc,
     status = valkeyAsyncFormattedCommand(ac, valkeyClusterAsyncCallback, cad,
                                          cmd, len);
     if (status != VALKEY_OK) {
+        valkeyClusterAsyncSetError(acc, ac->err, ac->errstr);
         goto error;
     }
     return VALKEY_OK;
@@ -3485,8 +3486,10 @@ int valkeyClusterAsyncFormattedCommandToNode(valkeyClusterAsyncContext *acc,
 
     status = valkeyAsyncFormattedCommand(ac, valkeyClusterAsyncCallback, cad,
                                          cmd, len);
-    if (status != VALKEY_OK)
+    if (status != VALKEY_OK) {
+        valkeyClusterAsyncSetError(acc, ac->err, ac->errstr);
         goto error;
+    }
 
     return VALKEY_OK;
 


### PR DESCRIPTION
When `valkeyAsyncFormattedCommand()` fail to push a given callback to its internal queue we need to free the `cluster_async_data` used in the cluster part (as privdata).
Additionally; keep the error message from `valkeyAsyncFormattedCommand()`.

This is the corresponding fix to https://github.com/Nordix/hiredis-cluster/pull/234 .