### PR TITLE
Don't initiate new connections during a cluster client disconnect (async API)

### DIFF
--- a/include/valkey/valkeycluster.h
+++ b/include/valkey/valkeycluster.h
@@ -58,6 +58,9 @@
 /* Flag to enable routing table updates using the command 'cluster slots'.
  * Default is the 'cluster nodes' command. */
 #define VALKEYCLUSTER_FLAG_ROUTE_USE_SLOTS 0x4000
+/* Flag specific to the async API which means that the user requested a
+ * client disconnect or free. */
+#define VALKEYCLUSTER_FLAG_DISCONNECTING 0x8000
 
 /* Events, for valkeyClusterSetEventCallback() */
 #define VALKEYCLUSTER_EVENT_SLOTMAP_UPDATED 1

--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -3267,7 +3267,8 @@ static void valkeyClusterAsyncCallback(valkeyAsyncContext *ac, void *r,
         goto done;
     }
 
-    if (cad->retry_count == NO_RETRY) /* Skip retry handling */
+    /* Skip retry handling when not expected, or during a client disconnect. */
+    if (cad->retry_count == NO_RETRY || cc->flags & VALKEYCLUSTER_FLAG_DISCONNECTING)
         goto done;
 
     error_type = cluster_reply_error_type(reply);

--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -3175,6 +3175,10 @@ static int updateSlotMapAsync(valkeyClusterAsyncContext *acc,
         /* Don't allow concurrent slot map updates. */
         return VALKEY_ERR;
     }
+    if (acc->cc->flags & VALKEYCLUSTER_FLAG_DISCONNECTING) {
+        /* No slot map updates during a cluster client disconnect. */
+        return VALKEY_ERR;
+    }
 
     if (ac == NULL) {
         if (acc->cc->nodes == NULL) {

--- a/src/valkeycluster.c
+++ b/src/valkeycluster.c
@@ -1795,6 +1795,10 @@ int valkeyClusterConnect2(valkeyClusterContext *cc) {
                               "server address not configured");
         return VALKEY_ERR;
     }
+    /* Clear a previously set shutdown flag since we allow a
+     * reconnection of an async context using this API (legacy). */
+    cc->flags &= ~VALKEYCLUSTER_FLAG_DISCONNECTING;
+
     return valkeyClusterUpdateSlotmap(cc);
 }
 
@@ -3383,6 +3387,12 @@ int valkeyClusterAsyncFormattedCommand(valkeyClusterAsyncContext *acc,
 
     cc = acc->cc;
 
+    /* Don't accept new commands when the client is about to disconnect. */
+    if (cc->flags & VALKEYCLUSTER_FLAG_DISCONNECTING) {
+        valkeyClusterAsyncSetError(acc, VALKEY_ERR_OTHER, "disconnecting");
+        return VALKEY_ERR;
+    }
+
     if (cc->err) {
         cc->err = 0;
         memset(cc->errstr, '\0', strlen(cc->errstr));
@@ -3457,19 +3467,23 @@ int valkeyClusterAsyncFormattedCommandToNode(valkeyClusterAsyncContext *acc,
                                              valkeyClusterCallbackFn *fn,
                                              void *privdata, char *cmd,
                                              int len) {
-    valkeyClusterContext *cc;
+    valkeyClusterContext *cc = acc->cc;
     valkeyAsyncContext *ac;
     int status;
     cluster_async_data *cad = NULL;
     struct cmd *command = NULL;
+
+    /* Don't accept new commands when the client is about to disconnect. */
+    if (cc->flags & VALKEYCLUSTER_FLAG_DISCONNECTING) {
+        valkeyClusterAsyncSetError(acc, VALKEY_ERR_OTHER, "disconnecting");
+        return VALKEY_ERR;
+    }
 
     ac = actx_get_by_node(acc, node);
     if (ac == NULL) {
         /* Specific error already set */
         return VALKEY_ERR;
     }
-
-    cc = acc->cc;
 
     if (cc->err) {
         cc->err = 0;
@@ -3646,6 +3660,7 @@ void valkeyClusterAsyncDisconnect(valkeyClusterAsyncContext *acc) {
     }
 
     cc = acc->cc;
+    cc->flags |= VALKEYCLUSTER_FLAG_DISCONNECTING;
 
     if (cc->nodes == NULL) {
         return;
@@ -3675,6 +3690,7 @@ void valkeyClusterAsyncFree(valkeyClusterAsyncContext *acc) {
     }
 
     cc = acc->cc;
+    cc->flags |= VALKEYCLUSTER_FLAG_DISCONNECTING;
 
     valkeyClusterFree(cc);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -264,4 +264,8 @@ if (LIBEVENT_LIBRARY)
            COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/slots-not-served-test-async.sh"
                    "$<TARGET_FILE:clusterclient_async>"
            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+  add_test(NAME client-disconnect-test-async
+           COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/client-disconnect-test.sh"
+                   "$<TARGET_FILE:clusterclient_async>"
+           WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -268,4 +268,8 @@ if (LIBEVENT_LIBRARY)
            COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/client-disconnect-test.sh"
                    "$<TARGET_FILE:clusterclient_async>"
            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+  add_test(NAME client-disconnect-without-slotmap-update-test-async
+           COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/client-disconnect-without-slotmap-update-test.sh"
+                   "$<TARGET_FILE:clusterclient_async>"
+           WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
 endif()

--- a/tests/scripts/client-disconnect-test.sh
+++ b/tests/scripts/client-disconnect-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Verify that a client disconnects from known nodes when requested
+# and will not accept new commands thereafter.
+#
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient_async}
+testname=client-disconnect-test
+
+# Sync processes waiting for CONT signals.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid1=$!;
+
+# Start simulated valkey node
+timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 16383, ["127.0.0.1", 7401, "nodeid1"]]]
+EXPECT CLOSE
+
+EXPECT CONNECT
+EXPECT ["SET", "foo", "initial"]
+SEND +OK
+
+EXPECT CLOSE
+EOF
+server1=$!
+
+# Wait until node is ready to accept client connections
+wait $syncpid1;
+
+# Run client
+timeout 4s "$clientprog" --connection-events 127.0.0.1:7401 > "$testname.out" <<'EOF'
+SET foo initial
+
+# Request a client disconnect.
+!disconnect
+
+# Commands are not accepted after a disconnect.
+SET foo not-accepted
+EOF
+clientexit=$?
+
+# Wait for server to exit
+wait $server1; server1exit=$?
+
+# Check exit statuses
+if [ $server1exit -ne 0 ]; then
+    echo "Simulated server #1 exited with status $server1exit"
+    exit $server1exit
+fi
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+expected="Event: connect to 127.0.0.1:7401
+OK
+Event: disconnect from 127.0.0.1:7401
+error: disconnecting"
+
+echo "$expected" | diff -u - "$testname.out" || exit 99
+
+# Clean up
+rm "$testname.out"

--- a/tests/scripts/client-disconnect-test.sh
+++ b/tests/scripts/client-disconnect-test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# Verify that a client disconnects from known nodes when requested
-# and will not accept new commands thereafter.
+# Verify that a client disconnects from known nodes without following
+# redirects, this to avoid reconnecting to already disconnected nodes.
+# The client will not accept new commands thereafter.
 #
 # Usage: $0 /path/to/clusterclient-binary
 
@@ -23,6 +24,9 @@ EXPECT CONNECT
 EXPECT ["SET", "foo", "initial"]
 SEND +OK
 
+EXPECT ["SET", "foo", "redirect"]
+SEND -MOVED 12182 127.0.0.1:7402
+
 EXPECT CLOSE
 EOF
 server1=$!
@@ -34,8 +38,12 @@ wait $syncpid1;
 timeout 4s "$clientprog" --connection-events 127.0.0.1:7401 > "$testname.out" <<'EOF'
 SET foo initial
 
-# Request a client disconnect.
+# Send a command that is expected to be redirected just before
+# requesting a client disconnect.
+!async
+SET foo redirect
 !disconnect
+!sync
 
 # Commands are not accepted after a disconnect.
 SET foo not-accepted
@@ -57,6 +65,7 @@ fi
 
 expected="Event: connect to 127.0.0.1:7401
 OK
+MOVED 12182 127.0.0.1:7402
 Event: disconnect from 127.0.0.1:7401
 error: disconnecting"
 

--- a/tests/scripts/client-disconnect-without-slotmap-update-test.sh
+++ b/tests/scripts/client-disconnect-without-slotmap-update-test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# Verify that a client disconnects from known nodes without starting new
+# slot map updates. A client shouldn't reconnect or connect to new nodes
+# while shutting down.
+#
+# This testcase starts 2 cluster nodes and the client connects to both.
+# The client triggers a disconnect right after a command has been sent,
+# which will invoke its callback with a NULL reply. This NULL reply
+# should not trigger a slot map update.
+#
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient_async}
+testname=client-disconnect-without-slotmap-update-test
+
+# Sync process just waiting for server to be ready to accept connection.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid1=$!
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid2=$!
+
+# Start simulated valkey node #1
+timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 6000, ["127.0.0.1", 7401, "nodeid1"]],[6001, 16383, ["127.0.0.1", 7402, "nodeid2"]]]
+EXPECT CLOSE
+
+EXPECT CONNECT
+EXPECT ["SET", "bar", "initial"]
+SEND +OK
+
+# Normally a slot map update is expected here, but not during disconnects.
+
+EXPECT CLOSE
+EOF
+server1=$!
+
+# Start simulated valkey node #2
+timeout 5s ./simulated-valkey.pl -p 7402 -d --sigcont $syncpid2 <<'EOF' &
+EXPECT CONNECT
+EXPECT ["SET", "foo", "initial"]
+SEND +OK
+
+EXPECT ["SET", "foo", "null-reply"]
+# The client will invoke callbacks for outstanding requests with a NULL reply.
+# Normally this would trigger a slot map update, but not during disconnects.
+
+EXPECT CLOSE
+EOF
+server2=$!
+
+# Wait until both nodes are ready to accept client connections
+wait $syncpid1 $syncpid2;
+
+# Run client
+timeout 4s "$clientprog" --connection-events 127.0.0.1:7401 > "$testname.out" <<'EOF'
+SET foo initial
+SET bar initial
+
+# Make sure a slot map update is not throttled.
+!sleep
+
+# Send a command just before requesting a client disconnect.
+# A NULL reply should not trigger a slot map update after a disconnect.
+!async
+SET foo null-reply
+!disconnect
+!sync
+
+EOF
+clientexit=$?
+
+# Wait for servers to exit
+wait $server1; server1exit=$?
+wait $server2; server2exit=$?
+
+# Check exit statuses
+if [ $server1exit -ne 0 ]; then
+    echo "Simulated server #1 exited with status $server1exit"
+    exit $server1exit
+fi
+if [ $server2exit -ne 0 ]; then
+    echo "Simulated server #2 exited with status $server2exit"
+    exit $server2exit
+fi
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+expected="Event: connect to 127.0.0.1:7402
+OK
+Event: connect to 127.0.0.1:7401
+OK
+Event: disconnect from 127.0.0.1:7401
+error: Timeout
+Event: failed to disconnect from 127.0.0.1:7402"
+
+echo "$expected" | diff -u - "$testname.out" || exit 99
+
+# Clean up
+rm "$testname.out"


### PR DESCRIPTION
- No slot map updates during a cluster client disconnect.
- Don't follow redirects when a cluster client disconnects.
- Don't accept new commands when a cluster client disconnects.

This is a corresponding change to https://github.com/Nordix/hiredis-cluster/pull/225 .