### PR TITLE
Fix build issues with Qt adapter example

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
 CC?=gcc
 CXX?=g++
 
-CFLAGS?=-Wall -Wextra -g -O2 -I../include
+CFLAGS?=-fPIC -Wall -Wextra -g -O2 -I../include
 STLIBNAME?=../lib/libvalkey.a
 
 # Define examples
@@ -88,11 +88,11 @@ example-async-qt:
 	@false
 else
 example-async-qt: async-qt.cpp $(STLIBNAME)
-	$(QT_MOC) .adapters/qt.h  -I$(QT_INCLUDE_DIR) -I$(QT_INCLUDE_DIR)/QtCore | \
+	$(QT_MOC) ../include/valkey/adapters/qt.h | \
 	    $(CXX) -x c++ -o qt-adapter-moc.o -c - $(CFLAGS) -I$(QT_INCLUDE_DIR) -I$(QT_INCLUDE_DIR)/QtCore
-	$(QT_MOC) async-qt.h -I$(QT_INCLUDE_DIR) -I$(QT_INCLUDE_DIR)/QtCore | \
+	$(QT_MOC) async-qt.h | \
 	    $(CXX) -x c++ -o qt-example-moc.o -c - $(CFLAGS) -I$(QT_INCLUDE_DIR) -I$(QT_INCLUDE_DIR)/QtCore
-	$(CXX) -o $@ $(CFLAGS) $(LDFLAGS) -I$(QT_INCLUDE_DIR) -I$(QT_INCLUDE_DIR)/QtCore -L$(QT_LIBRARY_DIR) qt-adapter-moc.o qt-example-moc.o $< -pthread $(STLIBNAME) -lQtCore
+	$(CXX) -o $@ $(CFLAGS) $(LDFLAGS) -I$(QT_INCLUDE_DIR) -I$(QT_INCLUDE_DIR)/QtCore -L$(QT_LIBRARY_DIR) qt-adapter-moc.o qt-example-moc.o $< -pthread $(STLIBNAME) -lQt6Core
 endif
 
 example-cluster-async: cluster-async.c $(STLIBNAME)

--- a/examples/async-qt.cpp
+++ b/examples/async-qt.cpp
@@ -4,7 +4,7 @@ using namespace std;
 #include <QCoreApplication>
 #include <QTimer>
 
-#include "example-qt.h"
+#include "async-qt.h"
 
 void getCallback(valkeyAsyncContext *, void * r, void * privdata) {
 


### PR DESCRIPTION
If Qt6 is installed the example can be built using:
```
cd examples
QT_MOC=$(qmake -query QT_HOST_LIBEXECS)/moc \
    QT_INCLUDE_DIR=$(qmake -query QT_INSTALL_HEADERS) \
    QT_LIBRARY_DIR=$(qmake -query QT_INSTALL_LIBS) \
    make example-async-qt
./example-async-qt
```
