### PR TITLE
Small changes after formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# This is a file that can be used by git-blame to ignore some revisions.
+# (git 2.23+, released in August 2019)
+#
+# Can be configured as follow:
+#
+#     $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# For more information you can look at git-blame(1) man page.
+
+# Applied clang-format 18.1.3 to all files
+60918c1f4ae38b0e6f2022b088e065b94564587c

--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ sudo make install
 ## Contributing
 
 Contributions from the community are welcome. Feel free to open a PR with a bugfix or new feature. Note that if you would like to merge a large feature it's probably a good idea to open an issue first rather than spending a lot of time on a PR that may not be accepted.
+
+When making a change, please use `git clang-format` or [format-files.sh](./scripts/format-files.sh) to format your changes properly. This repository is currently using `clang-format` 18.1.3 to format the code.


### PR DESCRIPTION
The first commit adds `.git-blame-ignore-revs` that lists the formatting commit so it would be omitted in `git blame`.

The second commit mentions `clang-format` version in README.