### PR TITLE
Enable release-drafter in CI

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -18,7 +18,6 @@ categories:
   - title: 'Breaking Changes'
     labels:
       - 'breakingchange'
-
   - title: '🧪 Experimental Features'
     labels:
       - 'experimental'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Enable the release drafter since it was used in hiredis,
and other clients under https://github.com/valkey-io seems keep using it.