### PR TITLE
Remove unused parsing of replicas/slaves in cluster API

### DIFF
--- a/examples/cluster-async-tls.c
+++ b/examples/cluster-async-tls.c
@@ -72,7 +72,6 @@ int main(int argc, char **argv) {
     valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE_TLS);
     valkeyClusterSetOptionRouteUseSlots(acc->cc);
-    valkeyClusterSetOptionParseSlaves(acc->cc);
     valkeyClusterSetOptionEnableSSL(acc->cc, ssl);
 
     if (valkeyClusterConnect2(acc->cc) != VALKEY_OK) {

--- a/examples/cluster-tls.c
+++ b/examples/cluster-tls.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv) {
     valkeyClusterSetOptionAddNodes(cc, CLUSTER_NODE_TLS);
     valkeyClusterSetOptionConnectTimeout(cc, timeout);
     valkeyClusterSetOptionRouteUseSlots(cc);
-    valkeyClusterSetOptionParseSlaves(cc);
     valkeyClusterSetOptionEnableSSL(cc, ssl);
     valkeyClusterConnect2(cc);
     if (!cc) {

--- a/include/valkey/valkeycluster.h
+++ b/include/valkey/valkeycluster.h
@@ -47,9 +47,6 @@
 
 /* Configuration flags */
 #define VALKEYCLUSTER_FLAG_NULL 0x0
-/* Flag to enable parsing of slave nodes. Currently not used, but the
-   information is added to its master node structure. */
-#define VALKEYCLUSTER_FLAG_ADD_SLAVE 0x1000
 /* Flag to enable routing table updates using the command 'cluster slots'.
  * Default is the 'cluster nodes' command. */
 #define VALKEYCLUSTER_FLAG_ROUTE_USE_SLOTS 0x4000
@@ -86,7 +83,6 @@ typedef struct valkeyClusterNode {
     valkeyAsyncContext *acon;
     int64_t lastConnectionAttempt; /* Timestamp */
     struct hilist *slots;
-    struct hilist *slaves;
 } valkeyClusterNode;
 
 typedef struct cluster_slot {
@@ -180,7 +176,6 @@ int valkeyClusterSetOptionUsername(valkeyClusterContext *cc,
                                    const char *username);
 int valkeyClusterSetOptionPassword(valkeyClusterContext *cc,
                                    const char *password);
-int valkeyClusterSetOptionParseSlaves(valkeyClusterContext *cc);
 int valkeyClusterSetOptionRouteUseSlots(valkeyClusterContext *cc);
 int valkeyClusterSetOptionConnectTimeout(valkeyClusterContext *cc,
                                          const struct timeval tv);
@@ -271,9 +266,8 @@ int valkeyClusterUpdateSlotmap(valkeyClusterContext *cc);
 valkeyContext *ctx_get_by_node(valkeyClusterContext *cc,
                                valkeyClusterNode *node);
 struct dict *parse_cluster_nodes(valkeyClusterContext *cc, char *str,
-                                 int str_len, int flags);
-struct dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply,
-                                 int flags);
+                                 int str_len);
+struct dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply);
 
 /*
  * Asynchronous API


### PR DESCRIPTION
The option to parse replicas are disabled by default and when enabled its not used for anything.