### PR TITLE
Add sanitizers to CI and fix a found test issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
             sanitizer: ""
             runner: ubuntu-20.04
     steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Prepare
       uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2
       with:
@@ -56,14 +57,14 @@ jobs:
       run: |
         git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
         cd valkey && BUILD_TLS=yes make install
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-    - name: Create build folder
-      run: cmake -E make_directory build
     - name: Generate makefiles
       env:
         CC: ${{ matrix.compiler }}
-      working-directory: build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DENABLE_SSL=ON -DENABLE_IPV6_TESTS=ON -DUSE_SANITIZER=${{ matrix.sanitizer }} ..
+      run: |
+        if [ -n "${{ matrix.sanitizer }}" ]; then
+          export CFLAGS="-fno-omit-frame-pointer -fsanitize=${{ matrix.sanitizer }}"
+        fi
+        cmake -B build -S . -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_SSL=ON -DENABLE_IPV6_TESTS=ON
     - name: Build
       working-directory: build
       run: VERBOSE=1 make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,24 +17,24 @@ jobs:
         clang-format-version: '18'
 
   ubuntu:
-    name: ${{ matrix.cmake-build-type }}-build [${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }} sanitizer="${{ matrix.sanitizer }}"]
+    name: ${{ matrix.cmake-build-type }} build [${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }} sanitizer="${{ matrix.sanitizer }}"]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-13, clang-18]
+        compiler: [gcc-14, clang-18]
         cmake-version: [3.29]
-        cmake-build-type: [Release, RelWithDebInfo]
+        cmake-build-type: [Release]
         sanitizer: ["", thread, undefined, leak, address]
-        runner: [ubuntu-22.04]
+        runner: [ubuntu-24.04]
         include:
           - compiler: gcc-7
-            cmake-version: 3.11
+            cmake-version: 3.13
             cmake-build-type: Release
             sanitizer: ""
             runner: ubuntu-20.04
           - compiler: clang-12
-            cmake-version: 3.11
+            cmake-version: 3.13
             cmake-build-type: Release
             sanitizer: ""
             runner: ubuntu-20.04

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -893,7 +893,7 @@ static void test_reply_reader(void) {
 
     test("Can parse RESP3 doubles in an array: ");
     reader = valkeyReaderCreate();
-    valkeyReaderFeed(reader, "*1\r\n,3.14159265358979323846\r\n", 31);
+    valkeyReaderFeed(reader, "*1\r\n,3.14159265358979323846\r\n", 29);
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_ARRAY &&


### PR DESCRIPTION
Update the CI workflow `ubuntu`:
- Build using the now available GCC 14.
- Build for Release only to use less CPU time.
- Enable sanitizers.

The PR includes:
- Fix `global-buffer-overflow` in client_test
  ..where the string length of "*1\r\n,3.14159265358979323846\r\n" is 29.