### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,44 +2,6 @@ name: Build and test
 on: [push, pull_request]
 
 jobs:
-  ubuntu:
-    name: Ubuntu
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y valgrind libevent-dev cmake libssl-dev
-
-      # TODO:  Test against Redis and KeyDB in addition to Valkey
-      - name: Install Valkey
-        run: |
-          git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
-          cd valkey && sudo BUILD_TLS=yes make install
-
-      - name: Build using cmake
-        env:
-          EXTRA_CMAKE_OPTS: -DENABLE_EXAMPLES:BOOL=ON -DENABLE_SSL:BOOL=ON
-        run: mkdir build && cd build && cmake .. && make
-
-      - name: Build using makefile
-        run: USE_SSL=1 TEST_ASYNC=1 make
-
-      - name: Run tests
-        working-directory: tests
-        env:
-          SKIPS_AS_FAILS: 1
-          TEST_SSL: 1
-        run: ./test.sh
-
-      #      - name: Run tests under valgrind
-      #        env:
-      #          SKIPS_AS_FAILS: 1
-      #          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
-      #        run: $GITHUB_WORKSPACE/test.sh
-
   almalinux8:
     name: AlmaLinux 8
     runs-on: ubuntu-latest
@@ -50,7 +12,7 @@ jobs:
       - name: Install dependencies
         run: |
           dnf -y install epel-release
-          dnf -y install gcc make cmake3 openssl openssl-devel libevent-devel valgrind procps-ng valkey
+          dnf -y install gcc make cmake3 openssl openssl-devel libevent-devel procps-ng valkey
 
       - name: Build using cmake
         env:
@@ -67,14 +29,6 @@ jobs:
           TEST_SSL: 1
         run: ./test.sh
 
-      - name: Run tests under valgrind
-        working-directory: tests
-        env:
-          SKIPS_AS_FAILS: 1
-          TEST_SSL: 1
-          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
-        run: ./test.sh
-
   centos8:
     name: RockyLinux 8
     runs-on: ubuntu-latest
@@ -88,7 +42,7 @@ jobs:
           dnf -y install https://rpms.remirepo.net/enterprise/remi-release-8.rpm
           dnf -y module install redis:remi-6.0
           dnf -y group install "Development Tools"
-          dnf -y install openssl-devel cmake valgrind libevent-devel
+          dnf -y install openssl-devel cmake libevent-devel
 
       - name: Install Valkey
         run: |
@@ -108,14 +62,6 @@ jobs:
         env:
           SKIPS_AS_FAILS: 1
           TEST_SSL: 1
-        run: ./test.sh
-
-      - name: Run tests under valgrind
-        working-directory: tests
-        env:
-          SKIPS_AS_FAILS: 1
-          TEST_SSL: 1
-          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
         run: ./test.sh
 
   freebsd:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       with:
         clang-format-version: '18'
 
-  ubuntu:
-    name: ${{ matrix.cmake-build-type }} build [${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }} sanitizer="${{ matrix.sanitizer }}"]
+  ubuntu-cmake:
+    name: Build with CMake [${{ matrix.cmake-build-type }}, ${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }}, sanitizer="${{ matrix.sanitizer }}"]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -81,6 +81,36 @@ jobs:
     - name: Teardown clusters
       working-directory: build
       run: make stop
+
+  ubuntu-make:
+    name: Build with make
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Prepare
+        uses: awalsh128/cache-apt-pkgs-action@a6c3917cc929dd0345bfb2d3feaf9101823370ad # v1.4.2
+        with:
+          packages: libevent-dev valgrind
+          version: 1.0
+      - name: Install Valkey
+        run: |
+          git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
+          cd valkey && sudo BUILD_TLS=yes make install
+      - name: Build
+        run: USE_SSL=1 TEST_ASYNC=1 make
+      - name: Run tests
+        working-directory: tests
+        env:
+          SKIPS_AS_FAILS: 1
+          TEST_SSL: 1
+        run: ./test.sh
+      - name: Run tests under valgrind
+        working-directory: tests
+        env:
+          SKIPS_AS_FAILS: 1
+          TEST_SSL: 1
+          TEST_PREFIX: valgrind --error-exitcode=99 --track-origins=yes --leak-check=full
+        run: ./test.sh
 
   install:
     name: Installation tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         sanitizer: ["", thread, undefined, leak, address]
         runner: [ubuntu-24.04]
         include:
+          - compiler: clang-18
+            cmake-version: 3.29
+            cmake-build-type: Debug
+            sanitizer: ""
+            runner: ubuntu-24.04
           - compiler: gcc-7
             cmake-version: 3.13
             cmake-build-type: Release


### PR DESCRIPTION
- Refactor and move the CI step to build using make.
 Run the tests under valgrind on Ubuntu only, which should be enough.

- Add a CMake build with type=Debug to make sure building without `-DNDEBUG` is fine.
    
