### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,11 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Install dependencies
-        run: brew install ninja valkey
+        run: brew install ninja
+      - name: Install Valkey for non-cluster tests
+        run: |
+          git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
+          cd valkey && BUILD_TLS=yes make install
       - name: Build using CMake
         run: |
           mkdir build && cd build

--- a/.github/workflows/db-compatibility.yml
+++ b/.github/workflows/db-compatibility.yml
@@ -13,6 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - valkey-version: '8.0.0'
           - valkey-version: '7.2.5'
     steps:
       - name: Prepare

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -144,7 +144,8 @@ static long long usec(void) {
     } while (1)
 
 /* Helper to extract server version information.  Aborts on any failure. */
-#define SERVER_VERSION_FIELD "redis_version:"
+#define VALKEY_VERSION_FIELD "valkey_version:"
+#define REDIS_VERSION_FIELD "redis_version:"
 void get_server_version(valkeyContext *c, int *majorptr, int *minorptr) {
     valkeyReply *reply;
     char *eptr, *s, *e;
@@ -153,10 +154,12 @@ void get_server_version(valkeyContext *c, int *majorptr, int *minorptr) {
     reply = valkeyCommand(c, "INFO");
     if (reply == NULL || c->err || reply->type != VALKEY_REPLY_STRING)
         goto abort;
-    if ((s = strstr(reply->str, SERVER_VERSION_FIELD)) == NULL)
+    if ((s = strstr(reply->str, VALKEY_VERSION_FIELD)) != NULL)
+        s += strlen(VALKEY_VERSION_FIELD);
+    else if ((s = strstr(reply->str, REDIS_VERSION_FIELD)) != NULL)
+        s += strlen(REDIS_VERSION_FIELD);
+    else
         goto abort;
-
-    s += strlen(SERVER_VERSION_FIELD);
 
     /* We need a field terminator and at least 'x.y.z' (5) bytes of data */
     if ((e = strstr(s, "\r\n")) == NULL || (e - s) < 5)

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -1886,14 +1886,14 @@ void subscribe_channel_a_cb(valkeyAsyncContext *ac, void *r, void *privdata) {
                strcmp(reply->element[2]->str, "Hello!") == 0);
         state->checkpoint++;
 
-        /* Unsubscribe to channels, including channel X & Z which we don't subscribe to */
-        valkeyAsyncCommand(ac, unexpected_cb,
-                           (void *)"unsubscribe should not call unexpected_cb()",
-                           "unsubscribe B X A A Z");
         /* Unsubscribe to patterns, none which we subscribe to */
         valkeyAsyncCommand(ac, unexpected_cb,
                            (void *)"punsubscribe should not call unexpected_cb()",
                            "punsubscribe");
+        /* Unsubscribe to channels, including channel X & Z which we don't subscribe to */
+        valkeyAsyncCommand(ac, unexpected_cb,
+                           (void *)"unsubscribe should not call unexpected_cb()",
+                           "unsubscribe B X A A Z");
         /* Send a regular command after unsubscribing, then disconnect */
         state->disconnect = 1;
         valkeyAsyncCommand(ac, integer_cb, state, "LPUSH mylist foo");


### PR DESCRIPTION
- Add Valkey 8 to the compatibility test in CI, which requires the following test update:
- Update test of pubsub-replies without a channel/pattern string.
    Perform the punsubscribe before entering non-pubsub mode since Valkey 8
    dont allow several UNSUBSCRIBE commands executed under non-pubsub mode.
    See https://github.com/valkey-io/valkey/pull/759

- Temporarily use Valkey 7.2.5 in CI for macOS to handle `error:0A000010F:SSL routines::bad length` error in test_throughput.
- Primarily use `valkey_version` from INFO to determine server version in test.




