### PR TITLE
Add a source code spellchecker to CI 

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -1,0 +1,20 @@
+# See https://github.com/crate-ci/typos/blob/master/docs/reference.md to configure typos.
+
+[files]
+extend-exclude = [
+    "src/cmddef.h", # Generated file.
+]
+
+# Source files
+[type.c.extend-identifiers]
+clen = "clen"
+[type.c.extend-words]
+fo = "fo" # Used in sds.c testcase.
+
+# Header files (sv = *.h)
+[type.sv.extend-identifiers]
+clen = "clen"
+
+# Scripts
+[type.sh.extend-identifiers]
+ue = "ue" # Used in tests/test.sh

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,15 +1,28 @@
-name: spellcheck
+name: Spellcheck
 on:
   workflow_dispatch:
   pull_request:
+
+permissions:
+  contents: read
+
 jobs:
-  check-spelling:
+  spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Check Spelling
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Run spellcheck
         uses: rojopolis/spellcheck-github-actions@b83ca7c1b5c285e4f2b43e209a455c74872ec341 # 0.42.0
         with:
           config_path: .github/spellcheck-settings.yml
           task_name: Markdown
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Install typos
+        uses: taiki-e/install-action@7348990d6a11d92f3e482c9b1bb48cf31ab7f658 # v2.44.7
+        with:
+          tool: typos
+      - name: Run typos
+        run: typos --config=.github/typos.toml

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -295,7 +295,7 @@ The callbacks are installed using the following functions:
 
 ```c
 status = valkeyClusterAsyncSetConnectCallback(acc, callbackFn);
-status = valkeyClusterAsyncSetDisonnectCallback(acc, callbackFn);
+status = valkeyClusterAsyncSetDisconnectCallback(acc, callbackFn);
 ```
 
 The callback functions should have the following prototype, aliased to `valkeyConnectCallback`:

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -189,7 +189,7 @@ static unsigned int keyHashSlot(char *key, int keylen) {
         if (key[e] == '}')
             break;
 
-    /* No '}' or nothing betweeen {} ? Hash the whole key. */
+    /* No '}' or nothing between {} ? Hash the whole key. */
     if (e == keylen || e == s + 1)
         return crc16(key, keylen) & 0x3FFF;
 
@@ -1949,7 +1949,7 @@ static valkeyClusterNode *getNodeFromRedirectReply(valkeyClusterContext *cc,
         *slotptr = vk_atoi(part[1], sdslen(part[1]));
     }
 
-    /* Find the last occurance of the port separator since
+    /* Find the last occurrence of the port separator since
      * IPv6 addresses can contain ':' */
     if ((p = strrchr(part[2], IP_PORT_SEPARATOR)) == NULL) {
         valkeyClusterSetError(cc, VALKEY_ERR_OTHER,

--- a/src/read.c
+++ b/src/read.c
@@ -330,7 +330,7 @@ static int processLineItem(valkeyReader *r) {
                 d = strtod((char *)buf, &eptr);
                 /* RESP3 only allows "inf", "-inf", and finite values, while
                  * strtod() allows other variations on infinity,
-                 * etc. We explicity handle our two allowed infinite cases and NaN
+                 * etc. We explicitly handle our two allowed infinite cases and NaN
                  * above, so strtod() should only result in finite values. */
                 if (buf[0] == '\0' || eptr != &buf[len] || !isfinite(d)) {
                     valkeyReaderSetError(r, VALKEY_ERR_PROTOCOL,

--- a/src/sds.c
+++ b/src/sds.c
@@ -288,7 +288,7 @@ sds sdsRemoveFreeSpace(sds s) {
     return s;
 }
 
-/* Return the total size of the allocation of the specifed sds string,
+/* Return the total size of the allocation of the specified sds string,
  * including:
  * 1) The sds header before the pointer.
  * 2) The string.
@@ -408,7 +408,7 @@ sds sdscatlen(sds s, const void *t, size_t len) {
     return s;
 }
 
-/* Append the specified null termianted C string to the sds string 's'.
+/* Append the specified null terminated C string to the sds string 's'.
  *
  * After the call, the passed sds string is no longer valid and all the
  * references must be substituted with the new pointer returned by the call. */

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -219,7 +219,7 @@ static void send_hello(valkeyContext *c, int version) {
     freeReplyObject(reply);
 }
 
-/* Togggle client tracking */
+/* Toggle client tracking */
 static void send_client_tracking(valkeyContext *c, const char *str) {
     valkeyReply *reply;
 
@@ -1846,7 +1846,7 @@ static void test_command_timeout_during_pubsub(struct config config) {
     assert(ac != NULL && ac->err == 0);
     valkeyLibeventAttach(ac, base);
 
-    /* Configure a command timout */
+    /* Configure a command timeout */
     struct timeval command_timeout = {.tv_sec = 2};
     valkeyAsyncSetTimeout(ac, command_timeout);
 

--- a/tests/scripts/command-from-callback-test.sh
+++ b/tests/scripts/command-from-callback-test.sh
@@ -24,7 +24,7 @@ syncpid3=$!
 
 # Start simulated valkey node #1
 timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
-# Inital topology
+# Initial slotmap update
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 6000, ["127.0.0.1", 7401, "nodeid1"]],[6001, 12000, ["127.0.0.1", 7402, "nodeid2"]],[12001, 16383, ["127.0.0.1", 7403, "nodeid3"]]]

--- a/tests/scripts/redirect-with-hostname-test.sh
+++ b/tests/scripts/redirect-with-hostname-test.sh
@@ -24,7 +24,7 @@ syncpid2=$!;
 
 # Start simulated valkey node #1
 timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
-# Inital slotmap update
+# Initial slotmap update
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["localhost", 7401, "nodeid1", ["ip", "192.168.254.254"]]]]

--- a/tests/scripts/redirect-with-ipv6-test.sh
+++ b/tests/scripts/redirect-with-ipv6-test.sh
@@ -15,7 +15,7 @@ syncpid2=$!;
 
 # Start simulated valkey node #1
 timeout 5s ./simulated-valkey.pl -p 7401 --ipv6 -d --sigcont $syncpid1 <<'EOF' &
-# Inital slotmap update
+# Initial slotmap update
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["::1", 7401, "nodeid1"]]]

--- a/tests/scripts/timeout-handling-test.sh
+++ b/tests/scripts/timeout-handling-test.sh
@@ -20,7 +20,7 @@ syncpid2=$!
 
 # Start simulated valkey node #1
 timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
-# Inital topology
+# Initial slotmap update
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 6000, ["127.0.0.1", 7401, "nodeid1"]],[6001, 16383, ["127.0.0.1", 7402, "nodeid2"]]]


### PR DESCRIPTION
Start using `typos` which also is used in the valkey project.
Includes corrections for found spelling errors.

Closes #17.