### PR TITLE
Refactor slotmap update functions

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -864,7 +864,7 @@ error:
 /**
  * Parse the "cluster nodes" command reply to nodes dict.
  */
-static dict *parse_cluster_nodes(valkeyClusterContext *cc, char *str, int str_len,
+static dict *parse_cluster_nodes(valkeyClusterContext *cc, valkeyReply *reply,
                                  int flags) {
     int ret;
     dict *nodes = NULL;
@@ -885,8 +885,8 @@ static dict *parse_cluster_nodes(valkeyClusterContext *cc, char *str, int str_le
         goto oom;
     }
 
-    start = str;
-    end = start + str_len;
+    start = reply->str;
+    end = start + reply->len;
 
     line_start = start;
 
@@ -1136,7 +1136,7 @@ static int handleClusterNodesReply(valkeyClusterContext *cc, valkeyContext *c) {
         return VALKEY_ERR;
     }
 
-    dict *nodes = parse_cluster_nodes(cc, reply->str, reply->len, cc->flags);
+    dict *nodes = parse_cluster_nodes(cc, reply, cc->flags);
     freeReplyObject(reply);
     return updateNodesAndSlotmap(cc, nodes);
 }
@@ -3046,7 +3046,7 @@ void clusterNodesReplyCallback(valkeyAsyncContext *ac, void *r,
     }
 
     valkeyClusterContext *cc = acc->cc;
-    dict *nodes = parse_cluster_nodes(cc, reply->str, reply->len, cc->flags);
+    dict *nodes = parse_cluster_nodes(cc, reply, cc->flags);
     if (updateNodesAndSlotmap(cc, nodes) != VALKEY_OK) {
         /* Ignore failures for now */
     }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1068,15 +1068,14 @@ static int clusterUpdateRouteSendCommand(valkeyClusterContext *cc,
                            VALKEY_COMMAND_CLUSTER_SLOTS :
                            VALKEY_COMMAND_CLUSTER_NODES);
     if (valkeyAppendCommand(c, cmd) != VALKEY_OK) {
-        const char *msg = (cc->flags & VALKEYCLUSTER_FLAG_ROUTE_USE_SLOTS ?
-                               "Command (cluster slots) send error." :
-                               "Command (cluster nodes) send error.");
-        valkeyClusterSetError(cc, c->err, msg);
+        valkeyClusterSetError(cc, c->err, c->errstr);
         return VALKEY_ERR;
     }
     /* Flush buffer to socket. */
-    if (valkeyBufferWrite(c, NULL) == VALKEY_ERR)
+    if (valkeyBufferWrite(c, NULL) == VALKEY_ERR) {
+        valkeyClusterSetError(cc, c->err, c->errstr);
         return VALKEY_ERR;
+    }
 
     return VALKEY_OK;
 }

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -173,6 +173,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             result = valkeyClusterConnect2(cc);
             assert(result == VALKEY_ERR);
+            ASSERT_STR_EQ(cc->errstr, "Out of memory");
         }
 
         prepare_allocation_test(cc, 128);
@@ -521,6 +522,7 @@ void test_alloc_failure_handling_async(void) {
             prepare_allocation_test(acc->cc, i);
             result = valkeyClusterConnect2(acc->cc);
             assert(result == VALKEY_ERR);
+            ASSERT_STR_EQ(acc->cc->errstr, "Out of memory");
         }
 
         prepare_allocation_test(acc->cc, 126);


### PR DESCRIPTION
- Merge `handleClusterSlotsReply` and `handleClusterNodesReply` into `clusterUpdateRouteHandleReply`.
    - Validate the reply in  `parse_cluster_slots` and `parse_cluster_nodes`
    - Remove redundant argument `flags` in `parse_cluster_slots` and `parse_cluster_nodes`
- Use error strings from the standalone context in both the send function (`clusterUpdateRouteSendCommand`) and the response function (`handleClusterSlotsReply`); making sure that specific error strings are used (like OOM).
- Update OOM test which now get correct error string.

