### PR TITLE
Use `-std=c99` when building with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,9 @@ OPTION(ENABLE_EXAMPLES "Enable building valkey examples" OFF)
 option(ENABLE_IPV6_TESTS "Enable IPv6 tests requiring special prerequisites" OFF)
 OPTION(ENABLE_RDMA "Build valkey_rdma for RDMA support" OFF)
 
-# valkey requires C99
+# Libvalkey requires C99 (-std=c99)
 SET(CMAKE_C_STANDARD 99)
+set(CMAKE_C_EXTENSIONS OFF)
 SET(CMAKE_DEBUG_POSTFIX d)
 
 # Set target-common flags

--- a/examples/async-libsdevent.c
+++ b/examples/async-libsdevent.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 600 /* Required by libsdevent (CLOCK_MONOTONIC) */
 #include <valkey/async.h>
 #include <valkey/valkey.h>
 

--- a/examples/async-libuv.c
+++ b/examples/async-libuv.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 600 /* Required by libuv (pthread_rwlock_t) */
 #include <valkey/async.h>
 #include <valkey/valkey.h>
 

--- a/examples/blocking.c
+++ b/examples/blocking.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 600 /* For strdup() */
 #include <valkey/valkey.h>
 
 #include <stdio.h>

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -30,7 +30,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#define _XOPEN_SOURCE 600
+#include "fmacros.h"
 #include "win32.h"
 
 #include "cluster.h"

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -1,6 +1,5 @@
-#if !defined(__FreeBSD__)
-#define _POSIX_C_SOURCE 200112L
-#endif
+#include "fmacros.h"
+
 #include "sockcompat.h"
 
 #include <stdio.h>

--- a/tests/ct_async_libuv.c
+++ b/tests/ct_async_libuv.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 600 /* Required by libuv (pthread_rwlock_t) */
 #include "adapters/libuv.h"
 #include "cluster.h"
 #include "test_utils.h"

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 600 /* For strdup() */
 #include "cluster.h"
 #include "test_utils.h"
 

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -24,6 +24,7 @@
  *   Correct `i` can be hard to know, finding the correct number might require trial
  *   and error of running with increased/decreased `i` until the edge is found.
  */
+#define _XOPEN_SOURCE 600 /* For strdup() */
 #include "adapters/libevent.h"
 #include "cluster.h"
 #include "test_utils.h"

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 600 /* For strdup() */
 #include "adapters/libevent.h"
 #include "cluster.h"
 #include "test_utils.h"

--- a/tests/ut_parse_cmd.c
+++ b/tests/ut_parse_cmd.c
@@ -1,5 +1,6 @@
 /* Some unit tests that don't require Valkey to be running. */
 
+#include "fmacros.h"
 #include "win32.h"
 
 #include "cluster.h"


### PR DESCRIPTION
Disable the GNU extensions in CMake, which is ON by default for some reason.
This enables `-std=c99` instead of `-std=gnu99`, same as in the Makefile.

Enable GNU extensions where required in examples and some tests.