### PR TITLE
Remove API `valkeyClusterSetOptionAddNode`

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -30,6 +30,7 @@ The type `sds` is removed from the public API.
 ### Removed API functions
 
 * `redisClusterSetMaxRedirect` removed and replaced with `valkeyClusterSetOptionMaxRetry`.
+* `redisClusterSetOptionAddNode` removed and replaced with `valkeyClusterSetOptionAddNodes`.
 * `redisClusterSetOptionConnectBlock` removed since it was deprecated.
 * `redisClusterSetOptionConnectNonBlock` removed since it was deprecated.
 * `parse_cluster_nodes` removed from API, for internal use only.

--- a/include/valkey/cluster.h
+++ b/include/valkey/cluster.h
@@ -171,7 +171,6 @@ valkeyClusterContext *valkeyClusterContextInit(void);
 void valkeyClusterFree(valkeyClusterContext *cc);
 
 /* Configuration options */
-int valkeyClusterSetOptionAddNode(valkeyClusterContext *cc, const char *addr);
 int valkeyClusterSetOptionAddNodes(valkeyClusterContext *cc, const char *addrs);
 int valkeyClusterSetOptionUsername(valkeyClusterContext *cc,
                                    const char *username);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1374,7 +1374,7 @@ valkeyClusterContext *valkeyClusterConnectWithTimeout(const char *addrs,
     return valkeyClusterConnectInternal(cc, addrs);
 }
 
-int valkeyClusterSetOptionAddNode(valkeyClusterContext *cc, const char *addr) {
+static int valkeyClusterSetOptionAddNode(valkeyClusterContext *cc, const char *addr) {
     dictEntry *node_entry;
     valkeyClusterNode *node = NULL;
     int port, ret;


### PR DESCRIPTION
The API valkeyClusterSetOptionAddNode**s** can be used instead.
It takes a single address, or multiple comma separated addresses.