### PR TITLE
Simplify API by only using non-const connect callbacks

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -298,19 +298,7 @@ status = valkeyClusterAsyncSetConnectCallback(acc, callbackFn);
 status = valkeyClusterAsyncSetDisconnectCallback(acc, callbackFn);
 ```
 
-The callback functions should have the following prototype, aliased to `valkeyConnectCallback`:
-
-```c
-void(const valkeyAsyncContext *ac, int status);
-```
-
-Alternatively, you set a connect callback that will be passed a non-const `valkeyAsyncContext*` on invocation (e.g. to be able to set a push callback on it).
-
-```c
-status = valkeyClusterAsyncSetConnectCallbackNC(acc, nonConstCallbackFn);
-```
-
-The callback function should have the following prototype, aliased to `valkeyConnectCallbackNC`:
+The connect callback function should have the following prototype, aliased to `valkeyConnectCallback`:
 ```c
 void(valkeyAsyncContext *ac, int status);
 ```

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -15,11 +15,15 @@ The general actions needed are:
 
 The type `sds` is removed from the public API.
 
+### Renamed API functions
+
+* `redisAsyncSetConnectCallbackNC` is renamed to `valkeyAsyncSetConnectCallback`.
+
 ### Removed API functions
 
 * `redisFormatSdsCommandArgv` removed from API. Can be replaced with `valkeyFormatCommandArgv`.
 * `redisFreeSdsCommand` removed since the `sds` type is for internal use only.
-* `redisAsyncSetConnectCallbackNC` removed and `valkeyAsyncSetConnectCallback` accepts the non-const callback function prototype.
+* `redisAsyncSetConnectCallback` is removed, but can be replaced with `valkeyAsyncSetConnectCallback` which accepts the non-const callback function prototype.
 
 ## Migrating from `hiredis-cluster` 0.14.0
 
@@ -27,6 +31,7 @@ The type `sds` is removed from the public API.
 
 * `ctx_get_by_node` is renamed to `valkeyClusterGetValkeyContext`.
 * `actx_get_by_node` is renamed to `valkeyClusterGetValkeyAsyncContext`.
+* `redisClusterAsyncSetConnectCallbackNC` is renamed to `valkeyClusterAsyncSetConnectCallback`.
 
 ### Renamed API defines
 
@@ -43,7 +48,7 @@ The type `sds` is removed from the public API.
 * `redisClusterSetOptionConnectNonBlock` removed since it was deprecated.
 * `parse_cluster_nodes` removed from API, for internal use only.
 * `parse_cluster_slots` removed from API, for internal use only.
-* `redisClusterAsyncSetConnectCallbackNC` removed  and `valkeyClusterAsyncSetConnectCallback` accepts the non-const callback function prototype.
+* `redisClutserAsyncSetConnectCallback` is removed, but can be replaced with `valkeyClusterAsyncSetConnectCallback` which accepts the non-const callback function prototype.
 
 ### Removed support for splitting multi-key commands per slot
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -19,6 +19,7 @@ The type `sds` is removed from the public API.
 
 * `redisFormatSdsCommandArgv` removed from API. Can be replaced with `valkeyFormatCommandArgv`.
 * `redisFreeSdsCommand` removed since the `sds` type is for internal use only.
+* `redisAsyncSetConnectCallbackNC` removed and `valkeyAsyncSetConnectCallback` accepts the non-const callback function prototype.
 
 ## Migrating from `hiredis-cluster` 0.14.0
 
@@ -42,6 +43,7 @@ The type `sds` is removed from the public API.
 * `redisClusterSetOptionConnectNonBlock` removed since it was deprecated.
 * `parse_cluster_nodes` removed from API, for internal use only.
 * `parse_cluster_slots` removed from API, for internal use only.
+* `redisClusterAsyncSetConnectCallbackNC` removed  and `valkeyClusterAsyncSetConnectCallback` accepts the non-const callback function prototype.
 
 ### Removed support for splitting multi-key commands per slot
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -48,7 +48,7 @@ The type `sds` is removed from the public API.
 * `redisClusterSetOptionConnectNonBlock` removed since it was deprecated.
 * `parse_cluster_nodes` removed from API, for internal use only.
 * `parse_cluster_slots` removed from API, for internal use only.
-* `redisClutserAsyncSetConnectCallback` is removed, but can be replaced with `valkeyClusterAsyncSetConnectCallback` which accepts the non-const callback function prototype.
+* `redisClusterAsyncSetConnectCallback` is removed, but can be replaced with `valkeyClusterAsyncSetConnectCallback` which accepts the non-const callback function prototype.
 
 ### Removed support for splitting multi-key commands per slot
 

--- a/examples/async-glib.c
+++ b/examples/async-glib.c
@@ -8,7 +8,7 @@
 static GMainLoop *mainloop;
 
 static void
-connect_cb(const valkeyAsyncContext *ac G_GNUC_UNUSED,
+connect_cb(valkeyAsyncContext *ac G_GNUC_UNUSED,
            int status) {
     if (status != VALKEY_OK) {
         g_printerr("Failed to connect: %s\n", ac->errstr);

--- a/examples/async-libev.c
+++ b/examples/async-libev.c
@@ -18,7 +18,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         return;

--- a/examples/async-libevent-tls.c
+++ b/examples/async-libevent-tls.c
@@ -19,7 +19,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         return;

--- a/examples/async-libevent.c
+++ b/examples/async-libevent.c
@@ -22,7 +22,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         return;

--- a/examples/async-libhv.c
+++ b/examples/async-libhv.c
@@ -30,7 +30,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         return;

--- a/examples/async-libsdevent.c
+++ b/examples/async-libsdevent.c
@@ -33,7 +33,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncCommand(c, debugCallback, NULL, "DEBUG SLEEP %f", 1.5);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("connect error: %s\n", c->errstr);
         return;

--- a/examples/async-libuv.c
+++ b/examples/async-libuv.c
@@ -33,7 +33,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncCommand(c, debugCallback, NULL, "DEBUG SLEEP %f", 1.5);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("connect error: %s\n", c->errstr);
         return;

--- a/examples/cluster-async-tls.c
+++ b/examples/cluster-async-tls.c
@@ -34,7 +34,7 @@ void setCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
     printf("privdata: %s reply: %s\n", (char *)privdata, reply->str);
 }
 
-void connectCallback(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", ac->errstr);
         return;

--- a/examples/cluster-async.c
+++ b/examples/cluster-async.c
@@ -30,7 +30,7 @@ void setCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
     printf("privdata: %s reply: %s\n", (char *)privdata, reply->str);
 }
 
-void connectCallback(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", ac->errstr);
         return;

--- a/examples/cluster-clientside-caching-async.c
+++ b/examples/cluster-clientside-caching-async.c
@@ -22,10 +22,9 @@ void getCallback1(valkeyClusterAsyncContext *acc, void *r, void *privdata);
 void getCallback2(valkeyClusterAsyncContext *acc, void *r, void *privdata);
 void modifyKey(const char *key, const char *value);
 
-/* The connect callback enables RESP3 and client tracking.
-   The non-const connect callback is used since we want to
-   set the push callback in the libvalkey context. */
-void connectCallbackNC(valkeyAsyncContext *ac, int status) {
+/* The connect callback enables RESP3 and client tracking,
+ * and sets the push callback in the libvalkey context. */
+void connectCallback(valkeyAsyncContext *ac, int status) {
     assert(status == VALKEY_OK);
     valkeyAsyncSetPushCallback(ac, pushCallback);
     valkeyAsyncCommand(ac, NULL, NULL, "HELLO 3");
@@ -147,7 +146,7 @@ int main(int argc, char **argv) {
     assert(acc);
 
     int status;
-    status = valkeyClusterAsyncSetConnectCallbackNC(acc, connectCallbackNC);
+    status = valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
     assert(status == VALKEY_OK);
     status = valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     assert(status == VALKEY_OK);

--- a/include/valkey/async.h
+++ b/include/valkey/async.h
@@ -64,8 +64,7 @@ typedef struct valkeyCallbackList {
 
 /* Connection callback prototypes */
 typedef void(valkeyDisconnectCallback)(const struct valkeyAsyncContext *, int status);
-typedef void(valkeyConnectCallback)(const struct valkeyAsyncContext *, int status);
-typedef void(valkeyConnectCallbackNC)(struct valkeyAsyncContext *, int status);
+typedef void(valkeyConnectCallback)(struct valkeyAsyncContext *, int status);
 typedef void(valkeyTimerCallback)(void *timer, void *privdata);
 
 /* Context for an async connection to Valkey */
@@ -101,7 +100,6 @@ typedef struct valkeyAsyncContext {
 
     /* Called when the first write event was received. */
     valkeyConnectCallback *onConnect;
-    valkeyConnectCallbackNC *onConnectNC;
 
     /* Regular command callbacks */
     valkeyCallbackList replies;
@@ -130,7 +128,6 @@ valkeyAsyncContext *valkeyAsyncConnectBindWithReuse(const char *ip, int port,
                                                     const char *source_addr);
 valkeyAsyncContext *valkeyAsyncConnectUnix(const char *path);
 int valkeyAsyncSetConnectCallback(valkeyAsyncContext *ac, valkeyConnectCallback *fn);
-int valkeyAsyncSetConnectCallbackNC(valkeyAsyncContext *ac, valkeyConnectCallbackNC *fn);
 int valkeyAsyncSetDisconnectCallback(valkeyAsyncContext *ac, valkeyDisconnectCallback *fn);
 
 valkeyAsyncPushFn *valkeyAsyncSetPushCallback(valkeyAsyncContext *ac, valkeyAsyncPushFn *fn);

--- a/include/valkey/cluster.h
+++ b/include/valkey/cluster.h
@@ -144,7 +144,6 @@ typedef struct valkeyClusterAsyncContext {
 
     /* Called when the first write event was received. */
     valkeyConnectCallback *onConnect;
-    valkeyConnectCallbackNC *onConnectNC;
 
 } valkeyClusterAsyncContext;
 
@@ -274,8 +273,6 @@ void valkeyClusterAsyncFree(valkeyClusterAsyncContext *acc);
 
 int valkeyClusterAsyncSetConnectCallback(valkeyClusterAsyncContext *acc,
                                          valkeyConnectCallback *fn);
-int valkeyClusterAsyncSetConnectCallbackNC(valkeyClusterAsyncContext *acc,
-                                           valkeyConnectCallbackNC *fn);
 int valkeyClusterAsyncSetDisconnectCallback(valkeyClusterAsyncContext *acc,
                                             valkeyDisconnectCallback *fn);
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2784,8 +2784,6 @@ valkeyClusterGetValkeyAsyncContext(valkeyClusterAsyncContext *acc,
 
     if (acc->onConnect) {
         valkeyAsyncSetConnectCallback(ac, acc->onConnect);
-    } else if (acc->onConnectNC) {
-        valkeyAsyncSetConnectCallbackNC(ac, acc->onConnectNC);
     }
 
     if (acc->onDisconnect) {
@@ -2849,18 +2847,7 @@ int valkeyClusterAsyncSetConnectCallback(valkeyClusterAsyncContext *acc,
                                          valkeyConnectCallback *fn) {
     if (acc->onConnect != NULL)
         return VALKEY_ERR;
-    if (acc->onConnectNC != NULL)
-        return VALKEY_ERR;
     acc->onConnect = fn;
-    return VALKEY_OK;
-}
-
-int valkeyClusterAsyncSetConnectCallbackNC(valkeyClusterAsyncContext *acc,
-                                           valkeyConnectCallbackNC *fn) {
-    if (acc->onConnectNC != NULL || acc->onConnect != NULL) {
-        return VALKEY_ERR;
-    }
-    acc->onConnectNC = fn;
     return VALKEY_OK;
 }
 

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -2173,7 +2173,7 @@ static valkeyAsyncContext *do_aconnect(struct config config, astest_no testno) {
     c->data = &astest;
     c->dataCleanup = asCleanup;
     valkeyPollAttach(c);
-    valkeyAsyncSetConnectCallbackNC(c, connectCallback);
+    valkeyAsyncSetConnectCallback(c, connectCallback);
     valkeyAsyncSetDisconnectCallback(c, disconnectCallback);
     return c;
 }

--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -207,7 +207,7 @@ void eventCallback(const valkeyClusterContext *cc, int event, void *privdata) {
     printf("Event: %s\n", e);
 }
 
-void connectCallback(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
     const char *s = "";
     if (status != VALKEY_OK)
         s = "failed to ";

--- a/tests/ct_async.c
+++ b/tests/ct_async.c
@@ -23,17 +23,9 @@ void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     ASSERT_MSG(reply != NULL, acc->errstr);
 }
 
-void connectCallback(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
     ASSERT_MSG(status == VALKEY_OK, ac->errstr);
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
-}
-
-void connectCallbackNC(valkeyAsyncContext *ac, int status) {
-    UNUSED(ac);
-    UNUSED(status);
-    /* The testcase expects a failure during registration of this
-       non-const connect callback and it should never be called. */
-    assert(0);
 }
 
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
@@ -76,8 +68,6 @@ int main(void) {
     status = valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
     assert(status == VALKEY_OK);
     status = valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
-    assert(status == VALKEY_ERR); /* Re-registration not accepted */
-    status = valkeyClusterAsyncSetConnectCallbackNC(acc, connectCallbackNC);
     assert(status == VALKEY_ERR); /* Re-registration not accepted */
 
     status = valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);

--- a/tests/ct_async_glib.c
+++ b/tests/ct_async_glib.c
@@ -24,7 +24,7 @@ void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     g_main_loop_quit(mainloop);
 }
 
-void connectCallback(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
     ASSERT_MSG(status == VALKEY_OK, ac->errstr);
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }

--- a/tests/ct_async_libev.c
+++ b/tests/ct_async_libev.c
@@ -21,7 +21,7 @@ void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyClusterAsyncDisconnect(acc);
 }
 
-void connectCallback(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
     ASSERT_MSG(status == VALKEY_OK, ac->errstr);
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }

--- a/tests/ct_async_libuv.c
+++ b/tests/ct_async_libuv.c
@@ -22,7 +22,7 @@ void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyClusterAsyncDisconnect(acc);
 }
 
-void connectCallback(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
     ASSERT_MSG(status == VALKEY_OK, ac->errstr);
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -313,7 +313,11 @@ typedef struct ExpectedResult {
 } ExpectedResult;
 
 // Callback for Valkey connects and disconnects
-void callbackExpectOk(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
+    UNUSED(ac);
+    assert(status == VALKEY_OK);
+}
+void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     UNUSED(ac);
     assert(status == VALKEY_OK);
 }
@@ -345,8 +349,8 @@ void commandCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
 void test_async_password_ok(void) {
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE_WITH_PASSWORD);
     valkeyClusterSetOptionPassword(acc->cc, CLUSTER_PASSWORD);
 
@@ -404,8 +408,8 @@ void test_async_password_wrong(void) {
 void test_async_password_missing(void) {
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE_WITH_PASSWORD);
     // Password not configured
 
@@ -434,8 +438,8 @@ void test_async_username_ok(void) {
     // Connect to the cluster using username and password
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE_WITH_PASSWORD);
     valkeyClusterSetOptionUsername(acc->cc, "missing-user");
     valkeyClusterSetOptionPassword(acc->cc, CLUSTER_PASSWORD);
@@ -478,14 +482,14 @@ void test_async_multicluster(void) {
 
     valkeyClusterAsyncContext *acc1 = valkeyClusterAsyncContextInit();
     assert(acc1);
-    valkeyClusterAsyncSetConnectCallback(acc1, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc1, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc1, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc1, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc1->cc, CLUSTER_NODE);
 
     valkeyClusterAsyncContext *acc2 = valkeyClusterAsyncContextInit();
     assert(acc2);
-    valkeyClusterAsyncSetConnectCallback(acc2, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc2, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc2, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc2, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc2->cc, CLUSTER_NODE_WITH_PASSWORD);
     valkeyClusterSetOptionPassword(acc2->cc, CLUSTER_PASSWORD);
 

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -453,7 +453,11 @@ typedef struct ExpectedResult {
 } ExpectedResult;
 
 // Callback for Valkey connects and disconnects
-void callbackExpectOk(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
+    UNUSED(ac);
+    assert(status == VALKEY_OK);
+}
+void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     UNUSED(ac);
     assert(status == VALKEY_OK);
 }
@@ -501,9 +505,9 @@ void test_alloc_failure_handling_async(void) {
     // Set callbacks
     {
         prepare_allocation_test_async(acc, 0);
-        result = valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
+        result = valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
         assert(result == VALKEY_OK);
-        result = valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+        result = valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
         assert(result == VALKEY_OK);
     }
 

--- a/tests/ct_pipeline.c
+++ b/tests/ct_pipeline.c
@@ -68,7 +68,11 @@ typedef struct ExpectedResult {
 } ExpectedResult;
 
 // Callback for Valkey connects and disconnects
-void callbackExpectOk(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
+    UNUSED(ac);
+    assert(status == VALKEY_OK);
+}
+void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     UNUSED(ac);
     assert(status == VALKEY_OK);
 }
@@ -93,8 +97,8 @@ void commandCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
 void test_async_pipeline(void) {
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
 
     int status;

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -277,7 +277,11 @@ typedef struct ExpectedResult {
 } ExpectedResult;
 
 // Callback for Valkey connects and disconnects
-void callbackExpectOk(const valkeyAsyncContext *ac, int status) {
+void connectCallback(valkeyAsyncContext *ac, int status) {
+    UNUSED(ac);
+    assert(status == VALKEY_OK);
+}
+void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     UNUSED(ac);
     assert(status == VALKEY_OK);
 }
@@ -318,8 +322,8 @@ void test_async_to_single_node(void) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
     valkeyClusterSetOptionMaxRetry(acc->cc, 1);
     valkeyClusterSetOptionRouteUseSlots(acc->cc);
@@ -351,8 +355,8 @@ void test_async_formatted_to_single_node(void) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
     valkeyClusterSetOptionMaxRetry(acc->cc, 1);
     valkeyClusterSetOptionRouteUseSlots(acc->cc);
@@ -385,8 +389,8 @@ void test_async_command_argv_to_single_node(void) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
     valkeyClusterSetOptionMaxRetry(acc->cc, 1);
     valkeyClusterSetOptionRouteUseSlots(acc->cc);
@@ -419,8 +423,8 @@ void test_async_to_all_nodes(void) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
     valkeyClusterSetOptionMaxRetry(acc->cc, 1);
     valkeyClusterSetOptionRouteUseSlots(acc->cc);
@@ -461,8 +465,8 @@ void test_async_transaction(void) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncContextInit();
     assert(acc);
-    valkeyClusterAsyncSetConnectCallback(acc, callbackExpectOk);
-    valkeyClusterAsyncSetDisconnectCallback(acc, callbackExpectOk);
+    valkeyClusterAsyncSetConnectCallback(acc, connectCallback);
+    valkeyClusterAsyncSetDisconnectCallback(acc, disconnectCallback);
     valkeyClusterSetOptionAddNodes(acc->cc, CLUSTER_NODE);
     valkeyClusterSetOptionMaxRetry(acc->cc, 1);
     valkeyClusterSetOptionRouteUseSlots(acc->cc);


### PR DESCRIPTION
Remove `valkeyAsyncSetConnectCallbackNC` since it was first added in hiredis for backwards-compatibility reasons,
and let `valkeyAsyncSetConnectCallback` use the non-const connect callback prototype.

Includes the removal of the cluster version `valkeyClusterAsyncSetConnectCallbackNC` and updates of tests.
