### PR TITLE
Handle empty addresses in `CLUSTER NODES` responses

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -788,13 +788,13 @@ static int parse_cluster_nodes_line(valkeyClusterContext *cc, char *line,
     while (*flags != '\0') {
         if ((p = strchr(flags, ',')) != NULL)
             *p = '\0';
-        if (memcmp(flags, "master", 6) == 0) {
+        if (memcmp(flags, "master", 6) == 0)
             role = VALKEY_ROLE_PRIMARY;
-            break;
-        }
-        if (memcmp(flags, "slave", 5) == 0) {
+        else if (memcmp(flags, "slave", 5) == 0)
             role = VALKEY_ROLE_REPLICA;
-            break;
+        else if (memcmp(flags, "noaddr", 6) == 0) {
+            *parsed_node = NULL;
+            return VALKEY_OK; /* Skip nodes with 'noaddr'. */
         }
         if (p == NULL) /* No more flags. */
             break;
@@ -837,12 +837,6 @@ static int parse_cluster_nodes_line(valkeyClusterContext *cc, char *line,
     }
     *p = '\0';
 
-    /* Skip nodes where address starts with ":0", i.e. 'noaddr'. */
-    if (strlen(addr) == 0) {
-        freeValkeyClusterNode(node);
-        *parsed_node = NULL;
-        return VALKEY_OK;
-    }
     node->host = sdsnew(addr);
     if (node->host == NULL)
         goto oom;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -748,11 +748,15 @@ static int store_replica_nodes(dict *nodes, dict *replicas) {
     return VALKEY_OK;
 }
 
-/* Parse a node from a single CLUSTER NODES line. Returns an allocated
- * valkeyClusterNode as a pointer in `parsed_node`.
+/* Parse a node from a single CLUSTER NODES line.
+ * Returns VALKEY_OK and an allocated valkeyClusterNode as a pointer in
+ * `parsed_node`, or VALKEY_ERR when the parsing fails.
  * Only parse primary nodes if the `parsed_primary_id` argument is NULL,
  * otherwise replicas are also parsed and its primary_id is returned by pointer
- * via 'parsed_primary_id'. */
+ * via 'parsed_primary_id'.
+ * The valkeyContext used when sending the CLUSTER NODES command should be
+ * provided in `c` since its destination IP address is used when no IP address
+ * is found in the parsed string. */
 static int parse_cluster_nodes_line(valkeyClusterContext *cc, valkeyContext *c, char *line,
                                     valkeyClusterNode **parsed_node, char **parsed_primary_id) {
     char *p, *id = NULL, *addr = NULL, *flags = NULL, *primary_id = NULL,

--- a/tests/ut_slotmap_update.c
+++ b/tests/ut_slotmap_update.c
@@ -225,8 +225,8 @@ void test_parse_cluster_nodes_with_empty_ip(void) {
     c->tcp.host = strdup("127.0.0.99");
 
     valkeyReply *reply = create_cluster_nodes_reply(
-        "752d150249c157c7cb312b6b056517bbbecb42d2 :6379@16379 master - 1658754833817 1658754833000 3 disconnected 5461-10922\n"
-        "e839a12fbed631de867016f636d773e644562e72 127.0.0.1:6379@16379 myself,master - 0 1658755601000 1 connected 0-5460\n"
+        "752d150249c157c7cb312b6b056517bbbecb42d2 :6379@16379 myself,master - 0 0 0 connected 5461-10922\n"
+        "e839a12fbed631de867016f636d773e644562e72 127.0.0.1:6379@16379 master - 0 1658755601000 1 connected 0-5460\n"
         "87f785c4a51f58c06e4be55de8c112210a811db9 127.0.0.2:6379@16379 master - 0 1658755602418 3 connected 10923-16383\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
     freeReplyObject(reply);

--- a/tests/ut_slotmap_update.c
+++ b/tests/ut_slotmap_update.c
@@ -181,7 +181,7 @@ void test_parse_cluster_nodes_during_failover(void) {
     valkeyClusterFree(cc);
 }
 
-/* Skip nodes with no address, i.e with address :0 */
+/* Skip nodes with the `noaddr` flag. */
 void test_parse_cluster_nodes_with_noaddr(void) {
     valkeyClusterContext *cc = valkeyClusterContextInit();
     valkeyClusterNode *node;
@@ -195,7 +195,7 @@ void test_parse_cluster_nodes_with_noaddr(void) {
     freeReplyObject(reply);
 
     assert(nodes);
-    assert(dictSize(nodes) == 2); /* Only 2 masters since ":0" is skipped. */
+    assert(dictSize(nodes) == 2); /* Only 2 primaries since `noaddr` nodes are skipped. */
     dictInitIterator(&di, nodes);
     /* Verify node 1 */
     node = dictGetEntryVal(dictNext(&di));
@@ -359,7 +359,7 @@ void test_parse_cluster_nodes_with_legacy_format(void) {
     freeReplyObject(reply);
 
     assert(nodes);
-    assert(dictSize(nodes) == 1); /* Only 1 master since ":0" is skipped. */
+    assert(dictSize(nodes) == 1); /* Only 1 primary since `noaddr` nodes are skipped. */
     dictInitIterator(&di, nodes);
     node = dictGetEntryVal(dictNext(&di));
     assert(strcmp(node->addr, "127.0.0.0:6379") == 0);


### PR DESCRIPTION
When parsing a `CLUSTER NODES` response we will now treat an empty IP string as it means the same endpoint as the response came from. This due to that the docs mention that an empty string is returned for the IP field when the node doesn't know its own IP address.
The created `valkeyClusterNode` will get its address from the `valkeyContext` used when sending the command.

Additional changes are that we will use the `noaddr` flag instead of the address length when deciding when a node should be skipped; and added validation of the port.

Example of a response snippet with an empty address:
"752d150249c157c7cb312b6b056517bbbecb42d2 **:6379**@&#65279;16379 myself,master - 1658754833817 1658754833000 3 connected 5461-10922"