### PR TITLE
Retry when an async slotmap update fails 

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -389,37 +389,9 @@ error:
  * Return a new node with the "cluster slots" command reply.
  */
 static valkeyClusterNode *node_get_with_slots(valkeyClusterContext *cc,
-                                              valkeyReply *host_elem,
-                                              valkeyReply *port_elem,
+                                              char *host, int port,
                                               uint8_t role) {
-    valkeyClusterNode *node = NULL;
-
-    if (host_elem == NULL || port_elem == NULL) {
-        return NULL;
-    }
-
-    if (host_elem->type != VALKEY_REPLY_STRING || host_elem->len <= 0) {
-        valkeyClusterSetError(cc, VALKEY_ERR_OTHER,
-                              "Command(cluster slots) reply error: "
-                              "node ip is not string.");
-        goto error;
-    }
-
-    if (port_elem->type != VALKEY_REPLY_INTEGER) {
-        valkeyClusterSetError(cc, VALKEY_ERR_OTHER,
-                              "Command(cluster slots) reply error: "
-                              "node port is not integer.");
-        goto error;
-    }
-
-    if (port_elem->integer < 1 || port_elem->integer > UINT16_MAX) {
-        valkeyClusterSetError(cc, VALKEY_ERR_OTHER,
-                              "Command(cluster slots) reply error: "
-                              "node port is not valid.");
-        goto error;
-    }
-
-    node = createValkeyClusterNode();
+    valkeyClusterNode *node = createValkeyClusterNode();
     if (node == NULL) {
         goto oom;
     }
@@ -433,29 +405,26 @@ static valkeyClusterNode *node_get_with_slots(valkeyClusterContext *cc,
         node->slots->free = listClusterSlotDestructor;
     }
 
-    node->addr = sdsnewlen(host_elem->str, host_elem->len);
+    node->addr = sdsnew(host);
     if (node->addr == NULL) {
         goto oom;
     }
-    node->addr = sdscatfmt(node->addr, ":%i", port_elem->integer);
+    node->addr = sdscatfmt(node->addr, ":%i", port);
     if (node->addr == NULL) {
         goto oom;
     }
-    node->host = sdsnewlen(host_elem->str, host_elem->len);
+    node->host = sdsnew(host);
     if (node->host == NULL) {
         goto oom;
     }
     node->name = NULL;
-    node->port = (int)port_elem->integer;
+    node->port = port;
     node->role = role;
 
     return node;
 
 oom:
     valkeyClusterSetError(cc, VALKEY_ERR_OOM, "Out of memory");
-    // passthrough
-
-error:
     if (node != NULL) {
         sdsfree(node->addr);
         sdsfree(node->host);
@@ -510,7 +479,8 @@ static void cluster_nodes_swap_ctx(dict *nodes_f, dict *nodes_t) {
 /**
  * Parse the "cluster slots" command reply to nodes dict.
  */
-static dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply) {
+static dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyContext *c,
+                                 valkeyReply *reply) {
     int ret;
     cluster_slot *slot = NULL;
     dict *nodes = NULL;
@@ -594,22 +564,39 @@ static dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply) {
                 elem_ip = elem_nodes->element[0];
                 elem_port = elem_nodes->element[1];
 
-                if (elem_ip == NULL || elem_port == NULL ||
-                    elem_ip->type != VALKEY_REPLY_STRING ||
-                    elem_port->type != VALKEY_REPLY_INTEGER) {
-                    valkeyClusterSetError(cc, VALKEY_ERR_OTHER,
-                                          "Command(cluster slots) reply error: "
-                                          "ip or port is not correct.");
+                /* Validate ip element. Accept a NULL value ip (NIL type) since
+                 * we will handle the unknown endpoint special. */
+                if (elem_ip == NULL || (elem_ip->type != VALKEY_REPLY_STRING &&
+                                        elem_ip->type != VALKEY_REPLY_NIL)) {
+                    valkeyClusterSetError(cc, VALKEY_ERR_OTHER, "Invalid node address");
                     goto error;
                 }
 
+                /* Validate port element. */
+                if (elem_port == NULL || elem_port->type != VALKEY_REPLY_INTEGER ||
+                    (elem_port->integer < 1 || elem_port->integer > UINT16_MAX)) {
+                    valkeyClusterSetError(cc, VALKEY_ERR_OTHER, "Invalid port");
+                    goto error;
+                }
+
+                /* Get the received ip/host. According to the docs an unknown
+                 * endpoint or an empty string can be treated as it means
+                 * the same address as we sent this command to.
+                 * An unknown endpoint has the type VALKEY_REPLY_NIL and its
+                 * length is initiated to zero. */
+                char *host = (elem_ip->len > 0) ? elem_ip->str : c->tcp.host;
+                if (host == NULL) {
+                    goto oom;
+                }
+                int port = elem_port->integer;
+
                 if (idx == 2) {
                     /* Parse a primary node. */
-                    sds address = sdsnewlen(elem_ip->str, elem_ip->len);
+                    sds address = sdsnew(host);
                     if (address == NULL) {
                         goto oom;
                     }
-                    address = sdscatfmt(address, ":%i", elem_port->integer);
+                    address = sdscatfmt(address, ":%i", port);
                     if (address == NULL) {
                         goto oom;
                     }
@@ -628,8 +615,7 @@ static dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply) {
                         break;
                     }
 
-                    primary = node_get_with_slots(cc, elem_ip, elem_port,
-                                                  VALKEY_ROLE_PRIMARY);
+                    primary = node_get_with_slots(cc, host, port, VALKEY_ROLE_PRIMARY);
                     if (primary == NULL) {
                         goto error;
                     }
@@ -654,7 +640,7 @@ static dict *parse_cluster_slots(valkeyClusterContext *cc, valkeyReply *reply) {
 
                     slot = NULL;
                 } else if (cc->flags & VALKEYCLUSTER_FLAG_ADD_SLAVE) {
-                    replica = node_get_with_slots(cc, elem_ip, elem_port,
+                    replica = node_get_with_slots(cc, host, port,
                                                   VALKEY_ROLE_REPLICA);
                     if (replica == NULL) {
                         goto error;
@@ -1061,7 +1047,7 @@ static int clusterUpdateRouteHandleReply(valkeyClusterContext *cc,
 
     dict *nodes;
     if (cc->flags & VALKEYCLUSTER_FLAG_ROUTE_USE_SLOTS) {
-        nodes = parse_cluster_slots(cc, reply);
+        nodes = parse_cluster_slots(cc, c, reply);
     } else {
         nodes = parse_cluster_nodes(cc, c, reply);
     }
@@ -2889,7 +2875,6 @@ int valkeyClusterAsyncSetDisconnectCallback(valkeyClusterAsyncContext *acc,
 /* Reply callback function for CLUSTER SLOTS */
 void clusterSlotsReplyCallback(valkeyAsyncContext *ac, void *r,
                                void *privdata) {
-    UNUSED(ac);
     valkeyReply *reply = (valkeyReply *)r;
     valkeyClusterAsyncContext *acc = (valkeyClusterAsyncContext *)privdata;
     acc->lastSlotmapUpdateAttempt = vk_usec_now();
@@ -2901,7 +2886,7 @@ void clusterSlotsReplyCallback(valkeyAsyncContext *ac, void *r,
     }
 
     valkeyClusterContext *cc = acc->cc;
-    dict *nodes = parse_cluster_slots(cc, reply);
+    dict *nodes = parse_cluster_slots(cc, &ac->c, reply);
     if (updateNodesAndSlotmap(cc, nodes) != VALKEY_OK) {
         /* Ignore failures for now */
     }
@@ -2910,7 +2895,6 @@ void clusterSlotsReplyCallback(valkeyAsyncContext *ac, void *r,
 /* Reply callback function for CLUSTER NODES */
 void clusterNodesReplyCallback(valkeyAsyncContext *ac, void *r,
                                void *privdata) {
-    UNUSED(ac);
     valkeyReply *reply = (valkeyReply *)r;
     valkeyClusterAsyncContext *acc = (valkeyClusterAsyncContext *)privdata;
     acc->lastSlotmapUpdateAttempt = vk_usec_now();

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2888,7 +2888,8 @@ void clusterSlotsReplyCallback(valkeyAsyncContext *ac, void *r,
     valkeyClusterContext *cc = acc->cc;
     dict *nodes = parse_cluster_slots(cc, &ac->c, reply);
     if (updateNodesAndSlotmap(cc, nodes) != VALKEY_OK) {
-        /* Ignore failures for now */
+        /* Retry using available nodes */
+        updateSlotMapAsync(acc, NULL);
     }
 }
 
@@ -2908,7 +2909,8 @@ void clusterNodesReplyCallback(valkeyAsyncContext *ac, void *r,
     valkeyClusterContext *cc = acc->cc;
     dict *nodes = parse_cluster_nodes(cc, &ac->c, reply);
     if (updateNodesAndSlotmap(cc, nodes) != VALKEY_OK) {
-        /* Ignore failures for now */
+        /* Retry using available nodes */
+        updateSlotMapAsync(acc, NULL);
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -279,4 +279,12 @@ if (LIBEVENT_LIBRARY)
            COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/client-disconnect-without-slotmap-update-test.sh"
                    "$<TARGET_FILE:clusterclient_async>"
            WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+  add_test(NAME connect-during-cluster-startup-test-async
+           COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/connect-during-cluster-startup-test.sh"
+                   "$<TARGET_FILE:clusterclient_async>"
+           WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
+  add_test(NAME connect-during-cluster-startup-using-cluster-nodes-test-async
+           COMMAND "${CMAKE_SOURCE_DIR}/tests/scripts/connect-during-cluster-startup-using-cluster-nodes-test.sh"
+                   "$<TARGET_FILE:clusterclient_async>"
+           WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/tests/scripts/")
 endif()

--- a/tests/scripts/connect-during-cluster-startup-test.sh
+++ b/tests/scripts/connect-during-cluster-startup-test.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+#
+# Connect to a cluster which is in the processes of starting up.
+#
+# The first attempt to get the slotmap will receive a reply without any
+# slot information and this should result in a retry.
+# The following slotmap updates tests the handling of an nil/empty IP address.
+#
+# The client is configured to use the CLUSTER SLOTS command.
+#
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient_async}
+testname=connect-during-cluster-startup-test
+
+# Sync process just waiting for server to be ready to accept connection.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid=$!
+
+# Start simulated server.
+timeout 5s ./simulated-valkey.pl -p 7400 -d --sigcont $syncpid <<'EOF' &
+# The initial slotmap is not covering any slots, expect a retry since it's not accepted.
+EXPECT CONNECT
+EXPECT ["CLUSTER", "SLOTS"]
+SEND []
+
+# The node has now been delegated a few slots and should be accepted.
+# Respond with an unknown endpoint (nil) to test that current connection IP is used instead.
+EXPECT ["CLUSTER", "SLOTS"]
+SEND *1\r\n*3\r\n:0\r\n:10\r\n*3\r\n$-1\r\n:7400\r\n$40\r\nf5378fa2ad1fbd569f01ba2fe29fa8feb36cdfb8\r\n
+
+# The node has now been delegated all slots.
+# Use empty address to test that current connection IP is used instead.
+EXPECT ["CLUSTER", "SLOTS"]
+SEND [[0, 16383, ["", 7400, "f5378fa2ad1fbd569f01ba2fe29fa8feb36cdfb8"]]]
+
+EXPECT ["SET", "foo", "bar3"]
+SEND +OK
+EXPECT CLOSE
+EOF
+server=$!
+
+# Wait until server is ready to accept client connection.
+wait $syncpid;
+
+# Run client which will fetch the initial slotmap asynchronously.
+timeout 3s "$clientprog" --events --async-initial-update 127.0.0.1:7400 > "$testname.out" <<'EOF'
+# Slot not yet handled, will trigger a slotmap update which will be throttled.
+SET foo bar1
+
+# Wait to avoid slotmap update throttling.
+!sleep
+
+# A command will fail direcly, but a slotmap update is scheduled.
+SET foo bar2
+
+# Allow slotmap update to finish.
+!sleep
+
+SET foo bar3
+EOF
+clientexit=$?
+
+# Wait for server to exit.
+wait $server; serverexit=$?
+
+# Check exit status on server.
+if [ $serverexit -ne 0 ]; then
+    echo "Simulated server exited with status $serverexit"
+    exit $serverexit
+fi
+# Check exit status on client.
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from the client.
+expected="Event: slotmap-updated
+Event: ready
+error: slot not served by any node
+error: slot not served by any node
+Event: slotmap-updated
+OK
+Event: free-context"
+
+echo "$expected" | diff -u - "$testname.out" || exit 99
+
+# Clean up.
+rm "$testname.out"

--- a/tests/scripts/connect-during-cluster-startup-test.sh
+++ b/tests/scripts/connect-during-cluster-startup-test.sh
@@ -51,7 +51,7 @@ SET foo bar1
 # Wait to avoid slotmap update throttling.
 !sleep
 
-# A command will fail direcly, but a slotmap update is scheduled.
+# A command will fail directly, but a slotmap update is scheduled.
 SET foo bar2
 
 # Allow slotmap update to finish.

--- a/tests/scripts/connect-during-cluster-startup-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-during-cluster-startup-using-cluster-nodes-test.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# Connect to a cluster which is in the processes of starting up.
+#
+# The first attempt to get the slotmap will receive a reply without any
+# slot information and this should result in a retry.
+#
+# The client is configured to use the CLUSTER NODES command.
+#
+# Usage: $0 /path/to/clusterclient-binary
+
+clientprog=${1:-./clusterclient_async}
+testname=connect-during-cluster-startup-using-cluster-nodes-test
+
+# Sync process just waiting for server to be ready to accept connection.
+perl -we 'use sigtrap "handler", sub{exit}, "CONT"; sleep 1; die "timeout"' &
+syncpid=$!
+
+# Start simulated server.
+timeout 5s ./simulated-valkey.pl -p 7400 -d --sigcont $syncpid <<'EOF' &
+# The initial slotmap is not covering any slots, expect a retry.
+EXPECT CONNECT
+EXPECT ["CLUSTER", "NODES"]
+SEND "8adca41945787ad1c9e725a40a43cf72bd4c6ad4 :7400@17400 myself,master - 0 0 0 connected\n"
+
+# The node has now been delegated slots.
+EXPECT ["CLUSTER", "NODES"]
+SEND "8adca41945787ad1c9e725a40a43cf72bd4c6ad4 :7400@17400 myself,master - 0 0 1 connected 0-16383\n"
+
+EXPECT ["SET", "foo", "bar"]
+SEND +OK
+EXPECT CLOSE
+EOF
+server=$!
+
+# Wait until server is ready to accept client connection.
+wait $syncpid;
+
+# Run client which will fetch the initial slotmap asynchronously using CLUSTER NODES.
+timeout 3s "$clientprog" --events --use-cluster-nodes --async-initial-update 127.0.0.1:7400 > "$testname.out" <<'EOF'
+SET foo bar
+EOF
+clientexit=$?
+
+# Wait for server to exit.
+wait $server; serverexit=$?
+
+# Check exit status on server.
+if [ $serverexit -ne 0 ]; then
+    echo "Simulated server exited with status $serverexit"
+    exit $serverexit
+fi
+# Check exit status on client.
+if [ $clientexit -ne 0 ]; then
+    echo "$clientprog exited with status $clientexit"
+    exit $clientexit
+fi
+
+# Check the output from the client.
+expected="Event: slotmap-updated
+Event: ready
+OK
+Event: free-context"
+
+echo "$expected" | diff -u - "$testname.out" || exit 99
+
+# Clean up.
+rm "$testname.out"

--- a/tests/scripts/dbsize-to-all-nodes-during-scaledown-test-async.sh
+++ b/tests/scripts/dbsize-to-all-nodes-during-scaledown-test-async.sh
@@ -81,26 +81,14 @@ if [ $clientexit -ne 0 ]; then
     exit $clientexit
 fi
 
-# Check the output from clusterclient, which depends on timing.
-# Client sends the second 'DBSIZE' to node #2 just after node #2 closes its socket.
-expected1="10
+# Check the output from clusterclient.
+expected="10
 20
-error: Server closed the connection
+error: Connection refused
 11
 12"
 
-# Client sends the second 'DBSIZE' to node #2 just before node #2 closes its socket.
-expected2="10
-20
-error: Connection reset by peer
-11
-12"
-
-# The reply "11" from node #1 can come before or after the socket error from node #2.
-# Therefore, we sort before comparing.
-diff -u <(echo "$expected1" | sort) <(sort "$testname.out") || \
-    diff -u <(echo "$expected2" | sort) <(sort "$testname.out") || \
-    exit 99
+echo "$expected" | diff -u - "$testname.out" || exit 99
 
 # Clean up
 rm "$testname.out"


### PR DESCRIPTION
Small fix to reattempt failing slotmap updates.

Additionally:

- Handle empty and NULL addresses in `CLUSTER SLOTS` responses.  
    As described in cluster slots docs:
  `Clients may treat the empty string in the same way as NULL,
     that is the same endpoint it used to send the current command to`
    
 - `clusterclient_async` received a new flag `--async-initial-update` to enable usage of `valkeyClusterAsyncConnect2`, which avoids blocking initial slotmap update.
  - Use short timeout when scheduling processing of next command in `clusterclient_async` and allow the event engine to read from sockets before next command, which improves predictability in tests.
     
Final change similar to https://github.com/Nordix/hiredis-cluster/pull/252.