### PR TITLE
SSL_library_init() is deprecated as of openssl v1.1.0

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -166,8 +166,8 @@ static int initOpensslLocks(void) {
 #endif /* VALKEY_USE_CRYPTO_LOCKS */
 
 int valkeyInitOpenSSL(void) {
-    SSL_library_init();
 #ifdef VALKEY_USE_CRYPTO_LOCKS
+    SSL_library_init();
     initOpensslLocks();
 #endif
 


### PR DESCRIPTION
According to the openss docs `SSL_library_init()` is deprecated as of openssl v1.1.0. We still need to call it when using crypto locks because we define that if openssl is < 1.1.0.

See: https://manpages.debian.org/experimental/libssl-doc/SSL_library_init.3ssl.en.html
See: https://docs.openssl.org/3.3/man3/OPENSSL_init_ssl/