### PR TITLE
Add tags into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lib
 compile_commands.json
 .cache
 /build*
+tags


### PR DESCRIPTION
ctags is used widely on a linux platform, add tags into .gitignore.