### PR TITLE
Fix Coverity warnings

### DIFF
--- a/src/valkey.c
+++ b/src/valkey.c
@@ -773,10 +773,10 @@ int valkeyReconnect(valkeyContext *c) {
     memset(c->errstr, '\0', strlen(c->errstr));
 
     assert(c->funcs);
-    if (c->funcs->close)
+    if (c->funcs && c->funcs->close)
         c->funcs->close(c);
 
-    if (c->privctx && c->funcs->free_privctx) {
+    if (c->privctx && c->funcs && c->funcs->free_privctx) {
         c->funcs->free_privctx(c->privctx);
         c->privctx = NULL;
     }
@@ -810,11 +810,13 @@ int valkeyReconnect(valkeyContext *c) {
         return VALKEY_ERR;
     }
 
-    if (c->funcs->connect(c, &options) != VALKEY_OK) {
+    if (c->funcs && c->funcs->connect &&
+        c->funcs->connect(c, &options) != VALKEY_OK) {
         return VALKEY_ERR;
     }
 
-    if (c->command_timeout != NULL && (c->flags & VALKEY_BLOCK) && c->fd != VALKEY_INVALID_FD) {
+    if (c->command_timeout != NULL && (c->flags & VALKEY_BLOCK) &&
+        c->fd != VALKEY_INVALID_FD && c->funcs && c->funcs->set_timeout) {
         c->funcs->set_timeout(c, *c->command_timeout);
     }
 

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -772,9 +772,9 @@ int valkeyReconnect(valkeyContext *c) {
     c->err = 0;
     memset(c->errstr, '\0', strlen(c->errstr));
 
-    if (c->funcs && c->funcs->close) {
+    assert(c->funcs);
+    if (c->funcs->close)
         c->funcs->close(c);
-    }
 
     if (c->privctx && c->funcs->free_privctx) {
         c->funcs->free_privctx(c->privctx);
@@ -860,6 +860,9 @@ valkeyContext *valkeyConnectWithOptions(const valkeyOptions *options) {
 
     c->privdata = options->privdata;
     c->free_privdata = options->free_privdata;
+    c->connection_type = options->type;
+    /* Make sure we set a valkeyContextFuncs before returning any context. */
+    valkeyContextSetFuncs(c);
 
     if (valkeyContextUpdateConnectTimeout(c, options->connect_timeout) != VALKEY_OK ||
         valkeyContextUpdateCommandTimeout(c, options->command_timeout) != VALKEY_OK) {
@@ -867,8 +870,6 @@ valkeyContext *valkeyConnectWithOptions(const valkeyOptions *options) {
         return c;
     }
 
-    c->connection_type = options->type;
-    valkeyContextSetFuncs(c);
     c->funcs->connect(c, options);
     if (c->err == 0 && c->fd != VALKEY_INVALID_FD &&
         options->command_timeout != NULL && (c->flags & VALKEY_BLOCK)) {

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -467,8 +467,8 @@ void test_alloc_failure_handling_async(void) {
         for (int i = 1; i < 100; ++i) {
             successfulAllocations = i;
             acc = valkeyClusterAsyncConnectWithOptions(&options);
-            ASSERT_STR_EQ(acc->errstr, "Out of memory");
             assert(acc != NULL);
+            ASSERT_STR_EQ(acc->errstr, "Out of memory");
             valkeyClusterAsyncFree(acc);
         }
         // Skip iteration 100 to 156 since sdscatfmt give leak warnings during OOM.


### PR DESCRIPTION
- Remove inconsistent check of `c->funcs` in `valkeyReconnect`.  
    Make sure we always set a `valkeyContextFuncs` before returning from `valkeyConnectWithOptions()`.
  We will then always have a `c->funcs` when calling `c->funcs->close`, `c->funcs->connect` and more in multiple places.
    
    **Fixes**: CID443767 "Comparing c->funcs to null implies that c->funcs might be null"

- Fix coverity issues in test.
   Check context before member of the context.
   
   **Fixes:** CID 456643: Dereference null return value (NULL_RETURNS)

    Use memcpy instead of strcpy to correct:
    "You might overrun the 256-character fixed-size string astest.errstr by copying c->errstr without checking the length."
    
    **Fixes:**
CID 443771: Copy into fixed size buffer (STRING_OVERFLOW)
                       CID 443768: Copy into fixed size buffer (STRING_OVERFLOW)
                       CID 443753: Copy into fixed size buffer (STRING_OVERFLOW)
