### PR TITLE
Update minimum required CMake version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,21 @@ jobs:
         cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/cmake-install/usr/local -DENABLE_TLS=ON ..
         make
 
+  cmake-minimum-required:
+    name: CMake 3.0.0 (min. required)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Setup CMake
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
+        with:
+          cmake-version: '3.0.0'
+      - name: Generate makefiles
+        run: |
+          mkdir build && cd build
+          cmake -DENABLE_TLS=ON -DENABLE_IPV6_TESTS=ON -DENABLE_EXAMPLES=ON ..
+          sudo make install
+
   macos:
     name: macOS
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,14 +180,14 @@ jobs:
         make
 
   cmake-minimum-required:
-    name: CMake 3.0.0 (min. required)
+    name: CMake 3.7.0 (min. required)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup CMake
         uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
-          cmake-version: '3.0.0'
+          cmake-version: '3.7.0'
       - name: Generate makefiles
         run: |
           mkdir build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.7.0)
 
 MACRO(getVersionBit name)
   SET(VERSION_REGEX "^#define ${name} (.+)$")


### PR DESCRIPTION
CMake 3.7.0 (released Nov. 2016) is required to get `FIND_PACKAGE(OpenSSL REQUIRED)`
to successfully generate the needed target `OpenSSL::SSL`.

This PR also adds a CI job to test that the minimum required CMake version can be used.
This showed that building with CMake 3.0 - 3.6 failed.

As reference Ubuntu 18.04 ships with CMake 3.10.
