### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,11 +209,9 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
-        run: brew install ninja
-      - name: Install Valkey for non-cluster tests
         run: |
-          git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
-          cd valkey && BUILD_TLS=yes make install
+          brew update
+          brew install valkey
       - name: Build using CMake
         run: |
           mkdir build && cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,23 +22,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-14, clang-19]
-        cmake-version: [3.29]
+        compiler: ['gcc-14', 'clang-20']
+        cmake-version: ['4.0']
         cmake-build-type: [Release]
         sanitizer: ["", thread, undefined, leak, address]
         include:
           - compiler: clang-18
             cmake-version: 3.29
             cmake-build-type: Debug
-            sanitizer: ""
           - compiler: gcc-9
             cmake-version: 3.13
             cmake-build-type: Release
-            sanitizer: ""
           - compiler: clang-14
             cmake-version: 3.13
             cmake-build-type: Release
-            sanitizer: ""
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
   ubuntu-cmake:
     name: Build with CMake [${{ matrix.cmake-build-type }}, ${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }}, sanitizer="${{ matrix.sanitizer }}"]
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,23 +26,19 @@ jobs:
         cmake-version: [3.29]
         cmake-build-type: [Release]
         sanitizer: ["", thread, undefined, leak, address]
-        runner: [ubuntu-24.04]
         include:
           - compiler: clang-18
             cmake-version: 3.29
             cmake-build-type: Debug
             sanitizer: ""
-            runner: ubuntu-24.04
           - compiler: gcc-9
             cmake-version: 3.13
             cmake-build-type: Release
             sanitizer: ""
-            runner: ubuntu-22.04
           - compiler: clang-14
             cmake-version: 3.13
             cmake-build-type: Release
             sanitizer: ""
-            runner: ubuntu-22.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Prepare
@@ -58,19 +54,11 @@ jobs:
       uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
       with:
         cmake-version: ${{ matrix.cmake-version }}
-    - name: Build and install Valkey for non-cluster tests
-      if: ${{ matrix.runner == 'ubuntu-22.04' }}
-      run: |
-        git clone --depth 1 --branch 7.2.5 https://github.com/valkey-io/valkey.git
-        cd valkey && BUILD_TLS=yes make install
     - name: Install Valkey for non-cluster tests
-      if: ${{ matrix.runner != 'ubuntu-22.04' }}
       run: |
         sudo apt update
         sudo apt install valkey
     - name: Generate makefiles
-      env:
-        CC: ${{ matrix.compiler }}
       run: |
         if [ -n "${{ matrix.sanitizer }}" ]; then
           export CFLAGS="-fno-omit-frame-pointer -fsanitize=${{ matrix.sanitizer }}"

--- a/.github/workflows/db-compatibility.yml
+++ b/.github/workflows/db-compatibility.yml
@@ -13,8 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - valkey-version: '8.0.0'
-          - valkey-version: '7.2.5'
+          - valkey-version: '8.1.0'
+          - valkey-version: '8.0.2'
+          - valkey-version: '7.2.8'
     steps:
       - name: Prepare
         uses: awalsh128/cache-apt-pkgs-action@7ca5f46d061ad9aa95863cd9b214dd48edef361d # v1.5.0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.7.0)
 project(examples LANGUAGES C)
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)


### PR DESCRIPTION
- Use valkey `8.1.0` in compatibility tests.
- Use latest version of clang (20) and cmake (4.0.0).
- Some cleanups.
All used compilers can now be installed on a `ubuntu-24.04` due to recent changes `inaminya/setup-cpp`,
 which also set the CC environment variable.
