### PR TITLE
CI: workaround the Windows vcpkg build issue of `libevent` when using CMake 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,11 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       - name: Install dependencies
         run: |
-          choco install -y ninja memurai-developer
+          choco install -y memurai-developer
+          # Workaround for libevent that specify minimum CMake version 3.1 (incompatible with CMake >= 4.0).
+          sed -i '2i if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")' ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
+          sed -i '3i   set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)'  ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
+          sed -i '4i endif()'                                       ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
           vcpkg install --triplet x64-windows pkgconf libevent
       - name: Build
         run: |


### PR DESCRIPTION
A temporary workaround to get a successful build of libevent when vcpkg builds and installs the package.
libevent specify minimum CMake version 3.1 in its CMakeLists.txt which is incompatible with CMake >= 4.0.

Setting vcpkg to use `CMAKE_POLICY_VERSION_MINIMUM 3.5` re-enables compability with older CMake versions.
CMake: `Changed in version 4.0: Compatibility with versions of CMake older than 3.5 is removed.`
