### PR TITLE
Introduce MPTCP

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -58,6 +58,8 @@ localhost
 Lua
 michael
 minimalistic
+MPTCP
+multipath
 musl
 namespace
 NOAUTOFREE

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Libvalkey is the official C client for the [Valkey](https://valkey.io) database.
 - Commands are executed in a generic way, with printf-like invocation.
 - Supports both `RESP2` and `RESP3` protocol versions.
 - Supports both synchronous and asynchronous operation.
-- Optional support for `TLS` and `RDMA` connections.
+- Optional support for `MPTCP`, `TLS` and `RDMA` connections.
 - Asynchronous API with several event libraries to choose from.
 - Supports both standalone and cluster mode operation.
 - Can be compiled with either `make` or `CMake`.

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -78,6 +78,7 @@ There are also several flags you can specify when using the `valkeyOptions` help
 | `VALKEY_OPT_NO_PUSH_AUTOFREE` | Tells libvalkey to not install the default RESP3 PUSH handler (which just intercepts and frees the replies).  This is useful in situations where you want to process these messages in-band. |
 | `VALKEY_OPT_NOAUTOFREEREPLIES` | **ASYNC**: tells libvalkey not to automatically invoke `freeReplyObject` after executing the reply callback. |
 | `VALKEY_OPT_NOAUTOFREE` | **ASYNC**: Tells libvalkey not to automatically free the `valkeyAsyncContext` on connection/communication failure, but only if the user makes an explicit call to `valkeyAsyncDisconnect` or `valkeyAsyncFree` |
+| `VALKEY_OPT_MPTCP` | Tells libvalkey to use multipath TCP (MPTCP). Note that only when both the server and client are using MPTCP do they establish an MPTCP connection between them; otherwise, they use a regular TCP connection instead. |
 
 ### Executing commands
 

--- a/include/valkey/net.h
+++ b/include/valkey/net.h
@@ -39,6 +39,7 @@
 
 void valkeyNetClose(valkeyContext *c);
 
+int valkeyHasMptcp(void);
 int valkeyCheckSocketError(valkeyContext *c);
 int valkeyTcpSetTimeout(valkeyContext *c, const struct timeval tv);
 int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options);

--- a/include/valkey/valkey.h
+++ b/include/valkey/valkey.h
@@ -100,6 +100,9 @@ typedef SSIZE_T ssize_t;
 #define VALKEY_PREFER_IPV4 0x800
 #define VALKEY_PREFER_IPV6 0x1000
 
+/* Flag specific to use Multipath TCP (MPTCP) */
+#define VALKEY_MPTCP 0x2000
+
 #define VALKEY_KEEPALIVE_INTERVAL 15 /* seconds */
 
 /* number of times we retry to connect in the case of EADDRNOTAVAIL and
@@ -169,7 +172,8 @@ enum valkeyConnectionType {
 #define VALKEY_OPT_PREFER_IPV4 0x20       /* Prefer IPv4 in DNS lookups. */
 #define VALKEY_OPT_PREFER_IPV6 0x40       /* Prefer IPv6 in DNS lookups. */
 #define VALKEY_OPT_PREFER_IP_UNSPEC (VALKEY_OPT_PREFER_IPV4 | VALKEY_OPT_PREFER_IPV6)
-#define VALKEY_OPT_LAST_SA_OPTION 0x40 /* Last defined standalone option. */
+#define VALKEY_OPT_MPTCP 0x80
+#define VALKEY_OPT_LAST_SA_OPTION 0x80 /* Last defined standalone option. */
 
 /* In Unix systems a file descriptor is a regular signed int, with -1
  * representing an invalid descriptor. In Windows it is a SOCKET
@@ -232,6 +236,14 @@ typedef struct {
         (opts)->type = VALKEY_CONN_TCP;          \
         (opts)->endpoint.tcp.ip = ip_;           \
         (opts)->endpoint.tcp.port = port_;       \
+    } while (0)
+
+#define VALKEY_OPTIONS_SET_MPTCP(opts, ip_, port_) \
+    do {                                           \
+        (opts)->type = VALKEY_CONN_TCP;            \
+        (opts)->endpoint.tcp.ip = ip_;             \
+        (opts)->endpoint.tcp.port = port_;         \
+        (opts)->options = VALKEY_OPT_MPTCP;        \
     } while (0)
 
 #define VALKEY_OPTIONS_SET_UNIX(opts, path)  \

--- a/include/valkey/valkey.h
+++ b/include/valkey/valkey.h
@@ -243,7 +243,7 @@ typedef struct {
         (opts)->type = VALKEY_CONN_TCP;            \
         (opts)->endpoint.tcp.ip = ip_;             \
         (opts)->endpoint.tcp.port = port_;         \
-        (opts)->options = VALKEY_OPT_MPTCP;        \
+        (opts)->options |= VALKEY_OPT_MPTCP;       \
     } while (0)
 
 #define VALKEY_OPTIONS_SET_UNIX(opts, path)  \

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -854,6 +854,10 @@ valkeyContext *valkeyConnectWithOptions(const valkeyOptions *options) {
         c->flags |= VALKEY_PREFER_IPV6;
     }
 
+    if (options->options & VALKEY_OPT_MPTCP) {
+        c->flags |= VALKEY_MPTCP;
+    }
+
     /* Set any user supplied RESP3 PUSH handler or use freeReplyObject
      * as a default unless specifically flagged that we don't want one. */
     if (options->push_cb != NULL)

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -855,6 +855,10 @@ valkeyContext *valkeyConnectWithOptions(const valkeyOptions *options) {
     }
 
     if (options->options & VALKEY_OPT_MPTCP) {
+        if (!valkeyHasMptcp()) {
+            valkeySetError(c, VALKEY_ERR_PROTOCOL, "MPTCP is not supported on this platform");
+            return c;
+        }
         c->flags |= VALKEY_MPTCP;
     }
 


### PR DESCRIPTION
Multipath TCP (MPTCP) is an extension of the standard TCP protocol that allows a single transport connection to use multiple network interfaces or paths. MPTCP is useful for applications like bandwidth aggregation, failover, and more resilient connections.

Linux kernel starts to support MPTCP since v5.6, it's time to support it.