### PR TITLE
Validate arguments for `%s`- and `%b`-format in `valkeyvFormatCommand`

### DIFF
--- a/src/valkey.c
+++ b/src/valkey.c
@@ -371,12 +371,16 @@ int valkeyvFormatCommand(char **target, const char *format, va_list ap) {
             switch (c[1]) {
             case 's':
                 arg = va_arg(ap, char *);
+                if (arg == NULL)
+                    goto format_err;
                 size = strlen(arg);
                 if (size > 0)
                     newarg = sdscatlen(curarg, arg, size);
                 break;
             case 'b':
                 arg = va_arg(ap, char *);
+                if (arg == NULL)
+                    goto format_err;
                 size = va_arg(ap, size_t);
                 if (size > 0)
                     newarg = sdscatlen(curarg, arg, size);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,9 @@ else()
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "" FORCE)
 endif()
 
+# Make sure ctest gives the output when tests fail
+list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
+
 # Add non-cluster tests
 add_executable(client_test client_test.c)
 target_include_directories(client_test PRIVATE "${PROJECT_SOURCE_DIR}/src")

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -407,6 +407,14 @@ static void test_format_commands(void) {
     len = valkeyFormatCommand(&cmd, "%-");
     test_cond(len == -1);
 
+    test("Format command with %%b and an invalid string (NULL string): ");
+    len = valkeyFormatCommand(&cmd, "%b", NULL, 45);
+    test_cond(len == -1);
+
+    test("Format command with %%s and an invalid string (NULL string): ");
+    len = valkeyFormatCommand(&cmd, "%s", NULL);
+    test_cond(len == -1);
+
     const char *argv[3];
     argv[0] = "SET";
     argv[1] = "foo\0xxx";


### PR DESCRIPTION
- Make sure the expected `char*` argument given to `%s` or `%b` is a valid pointer.
  Avoids SIGSEGV in `sdscatlen`/`memcpy`.
  
- Output failure log when a test fails in CMake builds