### PR TITLE
Correcting the connect callback in examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,8 +1,14 @@
 CC?=gcc
 CXX?=g++
 
-CFLAGS?=-fPIC -Wall -Wextra -g -O2 -I../include
+WARNINGS=-Wall -Wextra
+CFLAGS?=-fPIC -g -O2 $(WARNINGS) -I../include
 STLIBNAME?=../lib/libvalkey.a
+
+USE_WERROR?=1
+ifeq ($(USE_WERROR),1)
+  WARNINGS+=-Werror
+endif
 
 # Define examples
 EXAMPLES=example-blocking example-blocking-push example-async-libevent \

--- a/examples/async-ae.c
+++ b/examples/async-ae.c
@@ -21,7 +21,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         aeStop(loop);

--- a/examples/async-ivykis.c
+++ b/examples/async-ivykis.c
@@ -18,7 +18,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         return;

--- a/examples/async-macosx.c
+++ b/examples/async-macosx.c
@@ -48,7 +48,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         return;

--- a/examples/async-poll.c
+++ b/examples/async-poll.c
@@ -21,7 +21,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncDisconnect(c);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         exit_loop = 1;

--- a/examples/async-valkeymoduleapi.c
+++ b/examples/async-valkeymoduleapi.c
@@ -32,7 +32,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyAsyncCommand(c, debugCallback, NULL, "DEBUG SLEEP %f", 1.5);
 }
 
-void connectCallback(const valkeyAsyncContext *c, int status) {
+void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
         printf("Error: %s\n", c->errstr);
         return;


### PR DESCRIPTION
Some examples were missed when changing the connect callback signature in PR #142 to using a non-const context.

Add `-Werror` to the examples Makefile to find issues in CI.
Can be disabled by `USE_WERROR=0` as when building libvalkey.