### PR TITLE
Support additional client options in a cluster client

### DIFF
--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -81,6 +81,9 @@ There are also several flags you can specify in `valkeyClusterOptions.options`. 
 | `VALKEY_OPT_USE_CLUSTER_NODES` | Tells libvalkey to use the command `CLUSTER NODES` when updating its slot map (cluster topology).<br>Libvalkey uses `CLUSTER SLOTS` by default. |
 | `VALKEY_OPT_USE_REPLICAS` | Tells libvalkey to keep parsed information of replica nodes. |
 | `VALKEY_OPT_BLOCKING_INITIAL_UPDATE` | **ASYNC**: Tells libvalkey to perform the initial slot map update in a blocking fashion. The function call will wait for a slot map update before returning so that the returned context is immediately ready to accept commands. |
+| `VALKEY_OPT_REUSEADDR` | Tells libvalkey to set the [SO_REUSEADDR](https://man7.org/linux/man-pages/man7/socket.7.html) socket option |
+| `VALKEY_OPT_PREFER_IPV4`<br>`VALKEY_OPT_PREFER_IPV6`<br>`VALKEY_OPT_PREFER_IP_UNSPEC` | Informs libvalkey to either prefer IPv4 or IPv6 when invoking [getaddrinfo](https://man7.org/linux/man-pages/man3/gai_strerror.3.html).  `VALKEY_OPT_PREFER_IP_UNSPEC` will cause libvalkey to specify `AF_UNSPEC` in the getaddrinfo call, which means both IPv4 and IPv6 addresses will be searched simultaneously.<br>Libvalkey prefers IPv4 by default. |
+| `VALKEY_OPT_MPTCP` | Tells libvalkey to use multipath TCP (MPTCP). Note that only when both the server and client are using MPTCP do they establish an MPTCP connection between them; otherwise, they use a regular TCP connection instead. |
 
 ### Executing commands
 

--- a/include/valkey/cluster.h
+++ b/include/valkey/cluster.h
@@ -87,7 +87,8 @@ typedef struct valkeyClusterContext {
     char errstr[128]; /* String representation of error when applicable */
 
     /* Configurations */
-    int flags;                       /* Configuration flags */
+    int options;                     /* Client configuration */
+    int flags;                       /* Config and state flags */
     struct timeval *connect_timeout; /* TCP connect timeout */
     struct timeval *command_timeout; /* Receive and send timeout */
     int max_retry_count;             /* Allowed retry attempts */

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1267,7 +1267,7 @@ static int valkeyClusterContextInit(valkeyClusterContext *cc,
                              VALKEY_OPT_PREFER_IPV4 | VALKEY_OPT_PREFER_IPV6 |
                              VALKEY_OPT_PREFER_IP_UNSPEC | VALKEY_OPT_MPTCP);
     if (options->options & ~supported_options) {
-        valkeyClusterSetError(cc, VALKEY_ERR_OTHER, "All options not supported");
+        valkeyClusterSetError(cc, VALKEY_ERR_OTHER, "Unsupported options");
         return VALKEY_ERR;
     }
     cc->options = options->options;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1079,6 +1079,7 @@ static int cluster_update_route_by_addr(valkeyClusterContext *cc,
     VALKEY_OPTIONS_SET_TCP(&options, ip, port);
     options.connect_timeout = cc->connect_timeout;
     options.command_timeout = cc->command_timeout;
+    options.options = cc->options;
 
     c = valkeyConnectWithOptions(&options);
     if (c == NULL) {
@@ -1260,6 +1261,16 @@ static int valkeyClusterContextInit(valkeyClusterContext *cc,
         return VALKEY_ERR;
     }
     cc->requests->free = listCommandFree;
+
+    int supported_options = (VALKEY_OPT_USE_CLUSTER_NODES | VALKEY_OPT_USE_REPLICAS |
+                             VALKEY_OPT_BLOCKING_INITIAL_UPDATE | VALKEY_OPT_REUSEADDR |
+                             VALKEY_OPT_PREFER_IPV4 | VALKEY_OPT_PREFER_IPV6 |
+                             VALKEY_OPT_PREFER_IP_UNSPEC | VALKEY_OPT_MPTCP);
+    if (options->options & ~supported_options) {
+        valkeyClusterSetError(cc, VALKEY_ERR_OTHER, "All options not supported");
+        return VALKEY_ERR;
+    }
+    cc->options = options->options;
 
     if (options->options & VALKEY_OPT_USE_CLUSTER_NODES) {
         cc->flags |= VALKEY_FLAG_USE_CLUSTER_NODES;
@@ -1663,6 +1674,7 @@ valkeyContext *valkeyClusterGetValkeyContext(valkeyClusterContext *cc,
     VALKEY_OPTIONS_SET_TCP(&options, node->host, node->port);
     options.connect_timeout = cc->connect_timeout;
     options.command_timeout = cc->command_timeout;
+    options.options = cc->options;
 
     c = valkeyConnectWithOptions(&options);
     if (c == NULL) {
@@ -2704,6 +2716,7 @@ valkeyClusterGetValkeyAsyncContext(valkeyClusterAsyncContext *acc,
     VALKEY_OPTIONS_SET_TCP(&options, node->host, node->port);
     options.connect_timeout = acc->cc.connect_timeout;
     options.command_timeout = acc->cc.command_timeout;
+    options.options = acc->cc.options;
 
     node->lastConnectionAttempt = vk_usec_now();
 

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -26,6 +26,20 @@ void reset_counters(void) {
     connect_success_counter = connect_failure_counter = 0;
 }
 
+/* Creating a context using unsupported client options should give errors */
+void test_unsupported_option(void) {
+    valkeyClusterOptions options = {0};
+    options.initial_nodes = CLUSTER_NODE;
+    options.options = VALKEY_OPT_PREFER_IPV4;
+    options.options |= VALKEY_OPT_NONBLOCK; /* unsupported in cluster */
+
+    valkeyClusterContext *cc = valkeyClusterConnectWithOptions(&options);
+    assert(cc);
+    assert(strcmp(cc->errstr, "All options not supported") == 0);
+
+    valkeyClusterFree(cc);
+}
+
 // Connecting to a password protected cluster and
 // providing a correct password.
 void test_password_ok(void) {
@@ -537,6 +551,8 @@ void test_async_command_timeout(void) {
 }
 
 int main(void) {
+
+    test_unsupported_option();
 
     test_password_ok();
     test_password_wrong();

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -35,7 +35,7 @@ void test_unsupported_option(void) {
 
     valkeyClusterContext *cc = valkeyClusterConnectWithOptions(&options);
     assert(cc);
-    assert(strcmp(cc->errstr, "All options not supported") == 0);
+    assert(strcmp(cc->errstr, "Unsupported options") == 0);
 
     valkeyClusterFree(cc);
 }


### PR DESCRIPTION
When a cluster client is created a few options can be configured.
The following options are now also supported and will be used when creating a connection to a single cluster node:
`VALKEY_OPT_REUSEADDR`
`VALKEY_OPT_PREFER_IPV4`
`VALKEY_OPT_PREFER_IPV6`
`VALKEY_OPT_PREFER_IP_UNSPEC`
`VALKEY_OPT_MPTCP`