### PR TITLE
Use existing connections for blocking slotmap updates

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -2763,6 +2763,19 @@ static int valkeyClusterAsyncConnect(valkeyClusterAsyncContext *acc) {
             valkeyClusterAsyncSetError(acc, acc->cc.err, acc->cc.errstr);
             return VALKEY_ERR;
         }
+
+        /* Disconnect any non-async context used for the initial update. */
+        dictIterator di;
+        dictInitIterator(&di, acc->cc.nodes);
+        dictEntry *de;
+        while ((de = dictNext(&di)) != NULL) {
+            valkeyClusterNode *node = dictGetVal(de);
+            if (node->con) {
+                valkeyFree(node->con);
+                node->con = NULL;
+            }
+        }
+
         return VALKEY_OK;
     }
     /* Use non-blocking initial slotmap update. */

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -73,8 +73,6 @@ int main(int argc, char **argv) {
             show_events = 1;
         } else if (strcmp(argv[argindex], "--use-cluster-nodes") == 0) {
             use_cluster_nodes = 1;
-        } else if (strcmp(argv[argindex], "--blocking-initial-update") == 0) {
-            /* ignore */
         } else {
             fprintf(stderr, "Unknown argument: '%s'\n", argv[argindex]);
             exit(1);

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -73,6 +73,8 @@ int main(int argc, char **argv) {
             show_events = 1;
         } else if (strcmp(argv[argindex], "--use-cluster-nodes") == 0) {
             use_cluster_nodes = 1;
+        } else if (strcmp(argv[argindex], "--blocking-initial-update") == 0) {
+            /* ignore */
         } else {
             fprintf(stderr, "Unknown argument: '%s'\n", argv[argindex]);
             exit(1);

--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -57,7 +57,7 @@ int num_running = 0;
 int resend_failed_cmd = 0;
 int send_to_all = 0;
 int show_events = 0;
-int async_initial_update = 0;
+int blocking_initial_update = 0;
 
 void sendNextCommand(evutil_socket_t, short, void *);
 
@@ -251,8 +251,8 @@ int main(int argc, char **argv) {
             show_events = 1;
         } else if (strcmp(argv[optind], "--connection-events") == 0) {
             show_connection_events = 1;
-        } else if (strcmp(argv[optind], "--async-initial-update") == 0) {
-            async_initial_update = 1;
+        } else if (strcmp(argv[optind], "--blocking-initial-update") == 0) {
+            blocking_initial_update = 1;
         } else {
             fprintf(stderr, "Unknown argument: '%s'\n", argv[optind]);
         }
@@ -273,7 +273,7 @@ int main(int argc, char **argv) {
     options.command_timeout = &timeout;
     options.event_callback = eventCallback;
     options.max_retry = 1;
-    if (!async_initial_update) {
+    if (blocking_initial_update) {
         options.options = VALKEY_OPT_BLOCKING_INITIAL_UPDATE;
     }
     if (use_cluster_nodes) {

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -52,7 +52,8 @@ void test_password_ok(void) {
     ASSERT_MSG(cc && cc->err == 0, cc ? cc->errstr : "OOM");
     assert(connect_success_counter == 1); // for CLUSTER SLOTS
     load_valkey_version(cc);
-    assert(connect_success_counter == 2); // for checking valkey version
+    // Check that the initial slotmap update connection is reused.
+    assert(connect_success_counter == 1);
 
     // Test connection
     valkeyReply *reply;
@@ -62,7 +63,7 @@ void test_password_ok(void) {
     valkeyClusterFree(cc);
 
     // Check counters incremented by connect callback
-    assert(connect_success_counter == 3); // for SET (to a different node)
+    assert(connect_success_counter == 2); // for SET (to a different node)
     assert(connect_failure_counter == 0);
     reset_counters();
 }

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -318,7 +318,7 @@ void test_alloc_failure_handling(void) {
         freeReplyObject(reply);
 
         /* Test ASK reply handling with OOM */
-        for (int i = 0; i < 30; ++i) {
+        for (int i = 0; i < 45; ++i) {
             prepare_allocation_test(cc, i);
             reply = valkeyClusterCommand(cc, "GET foo");
             assert(reply == NULL);
@@ -326,7 +326,7 @@ void test_alloc_failure_handling(void) {
         }
 
         /* Test ASK reply handling without OOM */
-        prepare_allocation_test(cc, 30);
+        prepare_allocation_test(cc, 45);
         reply = valkeyClusterCommand(cc, "GET foo");
         CHECK_REPLY_STR(cc, reply, "one");
         freeReplyObject(reply);
@@ -347,7 +347,7 @@ void test_alloc_failure_handling(void) {
         freeReplyObject(reply);
 
         /* Test MOVED reply handling with OOM */
-        for (int i = 0; i < 31; ++i) {
+        for (int i = 0; i < 32; ++i) {
             prepare_allocation_test(cc, i);
             reply = valkeyClusterCommand(cc, "GET foo");
             assert(reply == NULL);
@@ -355,7 +355,7 @@ void test_alloc_failure_handling(void) {
         }
 
         /* Test MOVED reply handling without OOM */
-        prepare_allocation_test(cc, 31);
+        prepare_allocation_test(cc, 32);
         reply = valkeyClusterCommand(cc, "GET foo");
         CHECK_REPLY_STR(cc, reply, "one");
         freeReplyObject(reply);

--- a/tests/scripts/ask-redirect-connection-error-test.sh
+++ b/tests/scripts/ask-redirect-connection-error-test.sh
@@ -48,7 +48,7 @@ server1=$!
 wait $syncpid1;
 
 # Run client
-timeout 4s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
 SET foo initial
 
 !async

--- a/tests/scripts/ask-redirect-connection-error-test.sh
+++ b/tests/scripts/ask-redirect-connection-error-test.sh
@@ -20,9 +20,6 @@ timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["127.0.0.1", 7401, "nodeid123"]]]
-EXPECT CLOSE
-
-EXPECT CONNECT
 EXPECT ["SET", "foo", "initial"]
 SEND +OK
 
@@ -48,8 +45,9 @@ server1=$!
 wait $syncpid1;
 
 # Run client
-timeout 4s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
 SET foo initial
+!sleep
 
 !async
 SET foo timeout1

--- a/tests/scripts/ask-redirect-test.sh
+++ b/tests/scripts/ask-redirect-test.sh
@@ -16,8 +16,6 @@ timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["127.0.0.1", 7401, "nodeid123"]]]
-EXPECT CLOSE
-EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND -ASK 12182 127.0.0.1:7402
 # A second redirect is needed to test reuse of the new cluster node
@@ -46,7 +44,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
 GET foo
 GET foo
 EOF

--- a/tests/scripts/ask-redirect-test.sh
+++ b/tests/scripts/ask-redirect-test.sh
@@ -46,7 +46,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
 GET foo
 GET foo
 EOF

--- a/tests/scripts/ask-redirect-using-cluster-nodes-test.sh
+++ b/tests/scripts/ask-redirect-using-cluster-nodes-test.sh
@@ -48,7 +48,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --use-cluster-nodes 127.0.0.1:7400 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update --use-cluster-nodes 127.0.0.1:7400 > "$testname.out" <<'EOF'
 GET foo
 GET foo
 EOF

--- a/tests/scripts/client-disconnect-test.sh
+++ b/tests/scripts/client-disconnect-test.sh
@@ -35,7 +35,7 @@ server1=$!
 wait $syncpid1;
 
 # Run client
-timeout 4s "$clientprog" --connection-events 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" --blocking-initial-update --connection-events 127.0.0.1:7401 > "$testname.out" <<'EOF'
 SET foo initial
 
 # Send a command that is expected to be redirected just before

--- a/tests/scripts/client-disconnect-without-slotmap-update-test.sh
+++ b/tests/scripts/client-disconnect-without-slotmap-update-test.sh
@@ -55,7 +55,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 4s "$clientprog" --connection-events 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" --blocking-initial-update --connection-events 127.0.0.1:7401 > "$testname.out" <<'EOF'
 SET foo initial
 SET bar initial
 

--- a/tests/scripts/cluster-down-test.sh
+++ b/tests/scripts/cluster-down-test.sh
@@ -42,7 +42,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 4s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
 !async
 SET foo initial
 SET bar initial

--- a/tests/scripts/cluster-scale-down-test.sh
+++ b/tests/scripts/cluster-scale-down-test.sh
@@ -36,22 +36,17 @@ timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 5000, ["127.0.0.1", 7401, "nodeid1"]],[5001, 10000, ["127.0.0.1", 7402, "nodeid2"]],[10001, 16383, ["127.0.0.1", 7403, "nodeid3"]]]
-EXPECT CLOSE
 
 # The command "GET {foo}1" is first sent to the slot owner nodeid3, but since this
 # node does not exist the failed connection attempt will trigger a slotmap update.
-EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 8000, ["127.0.0.1", 7401, "nodeid1"]],[8001, 16383, ["127.0.0.1", 7402, "nodeid2"]]]
-EXPECT CLOSE
 
 # The send failure of "GET {foo}2" schedules a slotmap update, which is
 # performed when (and just before) the next command "GET {foo}3" is sent.
-EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["127.0.0.1", 7401, "nodeid1"]]]
-EXPECT CLOSE
-EXPECT CONNECT
+
 EXPECT ["GET", "{foo}3"]
 SEND "bar3"
 EXPECT CLOSE

--- a/tests/scripts/command-from-callback-test.sh
+++ b/tests/scripts/command-from-callback-test.sh
@@ -70,7 +70,7 @@ server3=$!
 wait $syncpid1 $syncpid2 $syncpid3;
 
 # Run client which resends failed commands in the reply callback
-timeout 4s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
 !resend
 !async
 GET foo

--- a/tests/scripts/connect-during-cluster-startup-test.sh
+++ b/tests/scripts/connect-during-cluster-startup-test.sh
@@ -44,7 +44,7 @@ server=$!
 wait $syncpid;
 
 # Run client which will fetch the initial slotmap asynchronously.
-timeout 3s "$clientprog" --events --async-initial-update 127.0.0.1:7400 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --events 127.0.0.1:7400 > "$testname.out" <<'EOF'
 # Slot not yet handled, will trigger a slotmap update which will be throttled.
 SET foo bar1
 

--- a/tests/scripts/connect-during-cluster-startup-using-cluster-nodes-test.sh
+++ b/tests/scripts/connect-during-cluster-startup-using-cluster-nodes-test.sh
@@ -37,7 +37,7 @@ server=$!
 wait $syncpid;
 
 # Run client which will fetch the initial slotmap asynchronously using CLUSTER NODES.
-timeout 3s "$clientprog" --events --use-cluster-nodes --async-initial-update 127.0.0.1:7400 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --events --use-cluster-nodes 127.0.0.1:7400 > "$testname.out" <<'EOF'
 SET foo bar
 EOF
 clientexit=$?

--- a/tests/scripts/connection-error-test.sh
+++ b/tests/scripts/connection-error-test.sh
@@ -44,7 +44,7 @@ server1=$!
 wait $syncpid1
 
 # Run client
-timeout 4s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
 SET bar initial
 
 # Send commands aimed for nodeid2

--- a/tests/scripts/dbsize-to-all-nodes-during-scaledown-test-async.sh
+++ b/tests/scripts/dbsize-to-all-nodes-during-scaledown-test-async.sh
@@ -53,7 +53,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 5s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 5s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
 !all
 DBSIZE
 DBSIZE

--- a/tests/scripts/dbsize-to-all-nodes-during-scaledown-test.sh
+++ b/tests/scripts/dbsize-to-all-nodes-during-scaledown-test.sh
@@ -25,8 +25,6 @@ timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 8383, ["127.0.0.1", 7401, "nodeid7401"]], [8384, 16383, ["127.0.0.1", 7402, "nodeid7402"]]]
-EXPECT CLOSE
-EXPECT CONNECT
 EXPECT ["DBSIZE"]
 SEND 10
 EXPECT ["DBSIZE"]

--- a/tests/scripts/dbsize-to-all-nodes-test.sh
+++ b/tests/scripts/dbsize-to-all-nodes-test.sh
@@ -16,8 +16,6 @@ timeout 5s ./simulated-valkey.pl -p 7403 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 8383, ["127.0.0.1", 7403, "nodeid7403"]], [8384, 16383, ["127.0.0.1", 7404, "nodeid7404"]]]
-EXPECT CLOSE
-EXPECT CONNECT
 EXPECT ["DBSIZE"]
 SEND 11
 EXPECT CLOSE
@@ -37,7 +35,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --blocking-initial-update 127.0.0.1:7403 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" 127.0.0.1:7403 > "$testname.out" <<'EOF'
 !all
 DBSIZE
 EOF

--- a/tests/scripts/dbsize-to-all-nodes-test.sh
+++ b/tests/scripts/dbsize-to-all-nodes-test.sh
@@ -37,7 +37,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" 127.0.0.1:7403 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update 127.0.0.1:7403 > "$testname.out" <<'EOF'
 !all
 DBSIZE
 EOF

--- a/tests/scripts/moved-redirect-test.sh
+++ b/tests/scripts/moved-redirect-test.sh
@@ -62,7 +62,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --events 127.0.0.1:7403 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update --events 127.0.0.1:7403 > "$testname.out" <<'EOF'
 GET foo
 !sleep
 GET foo

--- a/tests/scripts/moved-redirect-test.sh
+++ b/tests/scripts/moved-redirect-test.sh
@@ -24,10 +24,10 @@ timeout 5s ./simulated-valkey.pl -p 7403 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["127.0.0.1", 7403, "nodeid7403"]]]
-EXPECT CLOSE
+EXPECT ["GET", "foo"]
+SEND "bar"
 
 # Test 1: Handle MOVED redirect.
-EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND -MOVED 12182 127.0.0.1:7404
 EXPECT ["CLUSTER", "SLOTS"]
@@ -54,6 +54,7 @@ EXPECT ["GET", "foo"]
 SEND -MOVED 9718 :7403
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["127.0.0.1", 7403, "nodeid7403"]]]
+
 EXPECT CLOSE
 EOF
 server2=$!
@@ -62,7 +63,9 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --blocking-initial-update --events 127.0.0.1:7403 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --events 127.0.0.1:7403 > "$testname.out" <<'EOF'
+GET foo
+!sleep
 GET foo
 !sleep
 GET foo
@@ -90,6 +93,7 @@ fi
 # Check the output from clusterclient
 expected="Event: slotmap-updated
 Event: ready
+bar
 Event: slotmap-updated
 bar
 Event: slotmap-updated

--- a/tests/scripts/moved-redirect-using-cluster-nodes-test.sh
+++ b/tests/scripts/moved-redirect-using-cluster-nodes-test.sh
@@ -42,7 +42,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --use-cluster-nodes 127.0.0.1:7400 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update --use-cluster-nodes 127.0.0.1:7400 > "$testname.out" <<'EOF'
 GET foo
 EOF
 clientexit=$?

--- a/tests/scripts/redirect-with-hostname-test.sh
+++ b/tests/scripts/redirect-with-hostname-test.sh
@@ -28,10 +28,10 @@ timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["localhost", 7401, "nodeid1", ["ip", "192.168.254.254"]]]]
-EXPECT CLOSE
+EXPECT ["GET", "foo"]
+SEND "bar"
 
 # Verify ASK redirect
-EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND -ASK 12182 localhost:7402
 
@@ -63,8 +63,13 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --blocking-initial-update localhost:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" localhost:7401 > "$testname.out" <<'EOF'
+# Trigger initial slotmap update
 GET foo
+!sleep
+# Verify ASK redirect
+GET foo
+# Verify MOVED redirect
 GET foo
 EOF
 clientexit=$?
@@ -88,7 +93,7 @@ if [ $clientexit -ne 0 ]; then
 fi
 
 # Check the output from clusterclient
-printf 'bar\nbar\n' | cmp "$testname.out" - || exit 99
+printf 'bar\nbar\nbar\n' | cmp "$testname.out" - || exit 99
 
 # Clean up
 rm "$testname.out"

--- a/tests/scripts/redirect-with-hostname-test.sh
+++ b/tests/scripts/redirect-with-hostname-test.sh
@@ -63,7 +63,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" localhost:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update localhost:7401 > "$testname.out" <<'EOF'
 GET foo
 GET foo
 EOF

--- a/tests/scripts/redirect-with-ipv6-test.sh
+++ b/tests/scripts/redirect-with-ipv6-test.sh
@@ -54,7 +54,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" ::1:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update ::1:7401 > "$testname.out" <<'EOF'
 GET foo
 GET foo
 EOF

--- a/tests/scripts/redirect-with-ipv6-test.sh
+++ b/tests/scripts/redirect-with-ipv6-test.sh
@@ -19,10 +19,10 @@ timeout 5s ./simulated-valkey.pl -p 7401 --ipv6 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["::1", 7401, "nodeid1"]]]
-EXPECT CLOSE
+EXPECT ["GET", "foo"]
+SEND "bar"
 
 # Verify ASK redirect
-EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND -ASK 12182 ::1:7402
 
@@ -54,8 +54,13 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 3s "$clientprog" --blocking-initial-update ::1:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" ::1:7401 > "$testname.out" <<'EOF'
+# Trigger initial slotmap update
 GET foo
+!sleep
+# Verify ASK redirect
+GET foo
+# Verify MOVED redirect
 GET foo
 EOF
 clientexit=$?
@@ -79,7 +84,7 @@ if [ $clientexit -ne 0 ]; then
 fi
 
 # Check the output from clusterclient
-printf 'bar\nbar\n' | cmp "$testname.out" - || exit 99
+printf 'bar\nbar\nbar\n' | cmp "$testname.out" - || exit 99
 
 # Clean up
 rm "$testname.out"

--- a/tests/scripts/set-get-test.sh
+++ b/tests/scripts/set-get-test.sh
@@ -28,7 +28,7 @@ server=$!
 wait $syncpid;
 
 # Run client
-timeout 3s "$clientprog" 127.0.0.1:7400 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update 127.0.0.1:7400 > "$testname.out" <<'EOF'
 SET foo bar
 GET foo
 EOF

--- a/tests/scripts/set-get-test.sh
+++ b/tests/scripts/set-get-test.sh
@@ -14,8 +14,6 @@ timeout 5s ./simulated-valkey.pl -p 7400 -d --sigcont $syncpid <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["127.0.0.1", 7400, "nodeid123"]]]
-EXPECT CLOSE
-EXPECT CONNECT
 EXPECT ["SET", "foo", "bar"]
 SEND +OK
 EXPECT ["GET", "foo"]
@@ -28,7 +26,7 @@ server=$!
 wait $syncpid;
 
 # Run client
-timeout 3s "$clientprog" --blocking-initial-update 127.0.0.1:7400 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" 127.0.0.1:7400 > "$testname.out" <<'EOF'
 SET foo bar
 GET foo
 EOF

--- a/tests/scripts/slots-not-served-test-async.sh
+++ b/tests/scripts/slots-not-served-test-async.sh
@@ -32,7 +32,7 @@ server1=$!
 wait $syncpid1;
 
 # Run client
-timeout 3s "$clientprog" --events 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update --events 127.0.0.1:7401 > "$testname.out" <<'EOF'
 GET foo
 # Allow slotmap update to finish.
 !sleep

--- a/tests/scripts/slots-not-served-test.sh
+++ b/tests/scripts/slots-not-served-test.sh
@@ -15,23 +15,17 @@ timeout 5s ./simulated-valkey.pl -p 7401 -d --sigcont $syncpid1 <<'EOF' &
 EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 1, ["127.0.0.1", 7401, "nodeid7401"]]]
-EXPECT CLOSE
 
 # Slotmap update due to the slot for `foo1` is not served.
 # The reply is still missing slots.
-EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 1, ["127.0.0.1", 7401, "nodeid7401"]]]
-EXPECT CLOSE
 
 # Slotmap update due to the slot for `foo2` is not served.
 # The reply now has full slot coverage.
-EXPECT CONNECT
 EXPECT ["CLUSTER", "SLOTS"]
 SEND [[0, 16383, ["127.0.0.1", 7401, "nodeid7401"]]]
-EXPECT CLOSE
 
-EXPECT CONNECT
 EXPECT ["GET", "foo2"]
 SEND "bar2"
 EXPECT CLOSE
@@ -42,7 +36,7 @@ server1=$!
 wait $syncpid1;
 
 # Run client
-timeout 3s "$clientprog" --blocking-initial-update --events 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --events 127.0.0.1:7401 > "$testname.out" <<'EOF'
 GET foo1
 GET foo2
 EOF

--- a/tests/scripts/slots-not-served-test.sh
+++ b/tests/scripts/slots-not-served-test.sh
@@ -42,7 +42,7 @@ server1=$!
 wait $syncpid1;
 
 # Run client
-timeout 3s "$clientprog" --events 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 3s "$clientprog" --blocking-initial-update --events 127.0.0.1:7401 > "$testname.out" <<'EOF'
 GET foo1
 GET foo2
 EOF

--- a/tests/scripts/timeout-handling-test.sh
+++ b/tests/scripts/timeout-handling-test.sh
@@ -59,7 +59,7 @@ server2=$!
 wait $syncpid1 $syncpid2;
 
 # Run client
-timeout 4s "$clientprog" 127.0.0.1:7401 > "$testname.out" <<'EOF'
+timeout 4s "$clientprog" --blocking-initial-update 127.0.0.1:7401 > "$testname.out" <<'EOF'
 SET foo initial
 SET bar initial
 


### PR DESCRIPTION
Change so that we don't create a temporary connection when updating the slotmap in the blocking API.

When `VALKEY_FLAG_BLOCKING_INITIAL_UPDATE` is used (in the async-api) the connections are still temporary in the initial update.

Include a change in test:
- Use async initial slotmap updates by default in async tests.
Replace the command flag `--async-initial-update` in `clusterclient_async` with `--blocking-initial-update`.
    