### PR TITLE
Remove macro UNUSED from public API

### DIFF
--- a/examples/cluster-async-tls.c
+++ b/examples/cluster-async-tls.c
@@ -51,10 +51,7 @@ void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
-int main(int argc, char **argv) {
-    UNUSED(argc);
-    UNUSED(argv);
-
+int main(void) {
     valkeyTLSContext *tls;
     valkeyTLSContextError tls_error;
 

--- a/examples/cluster-async.c
+++ b/examples/cluster-async.c
@@ -46,9 +46,7 @@ void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
-int main(int argc, char **argv) {
-    (void)argc;
-    (void)argv;
+int main(void) {
     struct event_base *base = event_base_new();
 
     valkeyClusterOptions options = {0};

--- a/examples/cluster-clientside-caching-async.c
+++ b/examples/cluster-clientside-caching-async.c
@@ -139,9 +139,7 @@ void modifyKey(const char *key, const char *value) {
     valkeyClusterFree(cc);
 }
 
-int main(int argc, char **argv) {
-    (void)argc;
-    (void)argv;
+int main(void) {
     struct event_base *base = event_base_new();
 
     valkeyClusterOptions options = {0};

--- a/examples/cluster-simple.c
+++ b/examples/cluster-simple.c
@@ -3,9 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(int argc, char **argv) {
-    UNUSED(argc);
-    UNUSED(argv);
+int main(void) {
     struct timeval timeout = {1, 500000}; // 1.5s
 
     valkeyClusterOptions options = {0};

--- a/examples/cluster-tls.c
+++ b/examples/cluster-tls.c
@@ -6,10 +6,7 @@
 
 #define CLUSTER_NODE_TLS "127.0.0.1:7301"
 
-int main(int argc, char **argv) {
-    UNUSED(argc);
-    UNUSED(argv);
-
+int main(void) {
     valkeyTLSContext *tls;
     valkeyTLSContextError tls_error;
 

--- a/include/valkey/cluster.h
+++ b/include/valkey/cluster.h
@@ -36,8 +36,6 @@
 #include "async.h"
 #include "valkey.h"
 
-#define UNUSED(x) (void)(x)
-
 #define VALKEYCLUSTER_SLOTS 16384
 
 #define VALKEY_ROLE_UNKNOWN 0

--- a/src/sds.c
+++ b/src/sds.c
@@ -1220,7 +1220,6 @@ void sds_free(void *ptr) { s_free(ptr); }
 
 #include <stdio.h>
 
-#define UNUSED(x) (void)(x)
 int sdsTest(void) {
     {
         sds x = sdsnew("foo"), y;

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -5,6 +5,8 @@
 #include <winsock2.h> /* For struct timeval */
 #endif
 
+#define UNUSED(x) (void)(x)
+
 #define ASSERT_MSG(_x, _msg)                            \
     if (!(_x)) {                                        \
         fprintf(stderr, "ERROR: %s (%s)\n", _msg, #_x); \


### PR DESCRIPTION
Update the examples, which uses the public API, but keep the macro in test only.
Additionally remove an unused define in `sds.c`.