### PR TITLE
Update the installation tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,13 +155,15 @@ jobs:
         make DESTDIR=${{ github.workspace }}/static-cmake-install install
     - name: Build examples with Makefile using a Makefile-installed libvalkey
       run: |
-        make CFLAGS="-I${{ github.workspace }}/make-install/usr/local/include" \
-             STLIBNAME="${{ github.workspace }}/make-install/usr/local/lib/libvalkey.a" \
+        make STLIBNAME="${{ github.workspace }}/make-install/usr/local/lib/libvalkey.a" \
+             TLS_STLIBNAME="${{ github.workspace }}/make-install/usr/local/lib/libvalkey_tls.a" \
+             INCLUDE_DIR="${{ github.workspace }}/make-install/usr/local/include" \
              USE_TLS=1 -C examples
     - name: Build examples with Makefile using a CMake-installed libvalkey
       run: |
-        make CFLAGS="-I${{ github.workspace }}/static-cmake-install/usr/local/include" \
-             STLIBNAME="${{ github.workspace }}/static-cmake-install/usr/local/lib/libvalkey.a" \
+        make STLIBNAME="${{ github.workspace }}/static-cmake-install/usr/local/lib/libvalkey.a" \
+             TLS_STLIBNAME="${{ github.workspace }}/static-cmake-install/usr/local/lib/libvalkey_tls.a" \
+             INCLUDE_DIR="${{ github.workspace }}/static-cmake-install/usr/local/include" \
              USE_TLS=1 -C examples
     - name: Build examples with CMake using CMake-installed dynamic libraries
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,14 +140,19 @@ jobs:
       with:
         packages: libevent-dev libuv1-dev libev-dev libglib2.0-dev
         version: 1.0
-    - name: Install libvalkey using Makefile
+    - name: Install static and dynamic libraries using Makefile
       run: |
         make USE_TLS=1 DESTDIR=${{ github.workspace }}/make-install install
-    - name: Install libvalkey using CMake
+    - name: Install dynamic libraries using CMake
       run: |
-        mkdir build && cd build
+        mkdir build-dyn && cd build-dyn
         cmake -DDISABLE_TESTS=ON -DENABLE_TLS=ON ..
-        make DESTDIR=${{ github.workspace }}/cmake-install install
+        make DESTDIR=${{ github.workspace }}/dynamic-cmake-install install
+    - name: Install static libraries using CMake
+      run: |
+        mkdir build-static && cd build-static
+        cmake -DDISABLE_TESTS=ON -DENABLE_TLS=ON -DBUILD_SHARED_LIBS=OFF ..
+        make DESTDIR=${{ github.workspace }}/static-cmake-install install
     - name: Build examples with Makefile using a Makefile-installed libvalkey
       run: |
         make CFLAGS="-I${{ github.workspace }}/make-install/usr/local/include" \
@@ -155,13 +160,18 @@ jobs:
              USE_TLS=1 -C examples
     - name: Build examples with Makefile using a CMake-installed libvalkey
       run: |
-        make CFLAGS="-I${{ github.workspace }}/cmake-install/usr/local/include" \
-             STLIBNAME="${{ github.workspace }}/cmake-install/usr/local/lib/libvalkey.a" \
+        make CFLAGS="-I${{ github.workspace }}/static-cmake-install/usr/local/include" \
+             STLIBNAME="${{ github.workspace }}/static-cmake-install/usr/local/lib/libvalkey.a" \
              USE_TLS=1 -C examples
-    - name: Build examples with CMake using a CMake-installed libvalkey
+    - name: Build examples with CMake using CMake-installed dynamic libraries
       run: |
-        cd examples && mkdir build && cd build
-        cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/cmake-install/usr/local -DENABLE_TLS=ON ..
+        cd examples && mkdir build-dyn && cd build-dyn
+        cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/dynamic-cmake-install/usr/local -DENABLE_TLS=ON ..
+        make
+    - name: Build examples with CMake using CMake-installed static libraries
+      run: |
+        cd examples && mkdir build-static && cd build-static
+        cmake -DCMAKE_PREFIX_PATH=${{ github.workspace }}/static-cmake-install/usr/local -DENABLE_TLS=ON ..
         make
 
   rdma:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,14 +12,13 @@ else()
   include_directories(${CMAKE_SOURCE_DIR}/include)
 endif()
 
-# Check for GLib
+# Examples using GLib
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  pkg_check_modules(GLIB2 glib-2.0)
+  pkg_check_modules(GLIB2 IMPORTED_TARGET glib-2.0)
   if(GLIB2_FOUND)
     add_executable(example-async-glib async-glib.c)
-    target_include_directories(example-async-glib PUBLIC ${GLIB2_INCLUDE_DIRS})
-    target_link_libraries(example-async-glib valkey::valkey ${GLIB2_LIBRARIES})
+    target_link_libraries(example-async-glib valkey::valkey PkgConfig::GLIB2)
   endif()
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,14 +22,14 @@ if(PkgConfig_FOUND)
   endif()
 endif()
 
-find_path(LIBEV ev.h
-  HINTS /usr/local /usr/opt/local
-  ENV LIBEV_INCLUDE_DIR)
+# Examples using libev
+find_path(LIBEV ev.h)
 if(LIBEV)
   add_executable(example-async-libev async-libev.c)
   target_link_libraries(example-async-libev valkey::valkey ev)
 endif()
 
+# Examples using libevent
 find_path(LIBEVENT event.h)
 if(LIBEVENT)
   add_executable(example-async-libevent async-libevent.c)
@@ -41,24 +41,28 @@ if(LIBEVENT)
   endif()
 endif()
 
+# Examples using libhv
 find_path(LIBHV hv/hv.h)
 if(LIBHV)
   add_executable(example-async-libhv async-libhv.c)
   target_link_libraries(example-async-libhv valkey::valkey hv)
 endif()
 
+# Examples using libuv
 find_path(LIBUV uv.h)
 if(LIBUV)
   add_executable(example-async-libuv async-libuv.c)
   target_link_libraries(example-async-libuv valkey::valkey uv)
 endif()
 
+# Examples using libsystemd
 find_path(LIBSDEVENT systemd/sd-event.h)
 if(LIBSDEVENT)
   add_executable(example-async-libsdevent async-libsdevent.c)
   target_link_libraries(example-async-libsdevent valkey::valkey systemd)
 endif()
 
+# Examples using the RunLoop in Apple's CoreFoundation
 if(APPLE)
   find_library(CF CoreFoundation)
   add_executable(example-async-macosx async-macosx.c)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,6 +12,23 @@ else()
   include_directories(${CMAKE_SOURCE_DIR}/include)
 endif()
 
+add_executable(example-blocking blocking.c)
+target_link_libraries(example-blocking valkey::valkey)
+
+add_executable(example-blocking-push blocking-push.c)
+target_link_libraries(example-blocking-push valkey::valkey)
+
+add_executable(example-cluster-simple cluster-simple.c)
+target_link_libraries(example-cluster-simple valkey::valkey)
+
+if(ENABLE_TLS)
+  add_executable(example-blocking-tls blocking-tls.c)
+  target_link_libraries(example-blocking-tls valkey::valkey valkey::valkey_tls)
+
+  add_executable(example-cluster-tls cluster-tls.c)
+  target_link_libraries(example-cluster-tls valkey::valkey valkey::valkey_tls)
+endif()
+
 # Examples using GLib
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
@@ -35,9 +52,18 @@ if(LIBEVENT)
   add_executable(example-async-libevent async-libevent.c)
   target_link_libraries(example-async-libevent valkey::valkey event)
 
+  add_executable(example-cluster-async cluster-async.c)
+  target_link_libraries(example-cluster-async valkey::valkey event)
+
+  add_executable(example-cluster-clientside-caching-async cluster-clientside-caching-async.c)
+  target_link_libraries(example-cluster-clientside-caching-async valkey::valkey event)
+
   if(ENABLE_TLS)
     add_executable(example-async-libevent-tls async-libevent-tls.c)
     target_link_libraries(example-async-libevent-tls valkey::valkey valkey::valkey_tls event)
+
+    add_executable(example-cluster-async-tls cluster-async-tls.c)
+    target_link_libraries(example-cluster-async-tls valkey::valkey valkey::valkey_tls event)
   endif()
 endif()
 
@@ -67,36 +93,4 @@ if(APPLE)
   find_library(CF CoreFoundation)
   add_executable(example-async-macosx async-macosx.c)
   target_link_libraries(example-async-macosx valkey::valkey ${CF})
-endif()
-
-if(ENABLE_TLS)
-  add_executable(example-blocking-tls blocking-tls.c)
-  target_link_libraries(example-blocking-tls valkey::valkey valkey::valkey_tls)
-endif()
-
-add_executable(example-blocking blocking.c)
-target_link_libraries(example-blocking valkey::valkey)
-
-add_executable(example-blocking-push blocking-push.c)
-target_link_libraries(example-blocking-push valkey::valkey)
-
-if(LIBEVENT)
-  add_executable(example-cluster-async cluster-async.c)
-  target_link_libraries(example-cluster-async valkey::valkey event)
-
-  if(ENABLE_TLS)
-    add_executable(example-cluster-async-tls cluster-async-tls.c)
-    target_link_libraries(example-cluster-async-tls valkey::valkey valkey::valkey_tls event)
-  endif()
-
-  add_executable(example-cluster-clientside-caching-async cluster-clientside-caching-async.c)
-  target_link_libraries(example-cluster-clientside-caching-async valkey::valkey event)
-endif()
-
-add_executable(example-cluster-simple cluster-simple.c)
-target_link_libraries(example-cluster-simple valkey::valkey)
-
-if(ENABLE_TLS)
-  add_executable(example-cluster-tls cluster-tls.c)
-  target_link_libraries(example-cluster-tls valkey::valkey valkey::valkey_tls)
 endif()

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,9 +1,12 @@
 CC?=gcc
 CXX?=g++
 
-WARNINGS=-Wall -Wextra
-CFLAGS?=-fPIC -g -O2 $(WARNINGS) -I../include
 STLIBNAME?=../lib/libvalkey.a
+TLS_STLIBNAME?=../lib/libvalkey_tls.a
+INCLUDE_DIR?=../include
+
+WARNINGS=-Wall -Wextra
+CFLAGS?=-fPIC -g -O2 $(WARNINGS) -I $(INCLUDE_DIR)
 
 USE_WERROR?=1
 ifeq ($(USE_WERROR),1)
@@ -19,7 +22,6 @@ EXAMPLES=example-blocking example-blocking-push example-async-libevent \
 ifeq ($(USE_TLS),1)
   EXAMPLES+=example-blocking-tls example-async-libevent-tls \
 	    example-cluster-async-tls example-cluster-tls
-  TLS_STLIBNAME=../lib/libvalkey_tls.a
   TLS_LDFLAGS=-lssl -lcrypto
 endif
 


### PR DESCRIPTION
- Correcting CI and the Makefile so that the installed include-files and `libvalkey_tls.a` are used by the installation tests in CI.
- Add installation test of CMake built static libraries.
- Simplify the examples CMakeLists.txt by cleanups, grouping targets using TLS and libevent, and adding comments.
