### PR TITLE
Only install headers for `TLS` and `RDMA` when enabled in CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,11 +212,11 @@ jobs:
         run: |
           brew update
           brew install valkey
-      - name: Build using CMake
+      - name: Build and install using CMake
         run: |
           mkdir build && cd build
           cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TLS=ON
-          ninja -v
+          sudo ninja -v install
       - name: Build using Makefile
         run: USE_TLS=1 make
       - name: Run tests
@@ -242,12 +242,11 @@ jobs:
           sed -i '3i   set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)'  ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
           sed -i '4i endif()'                                       ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
           vcpkg install --triplet x64-windows pkgconf libevent
-
-      - name: Build
+      - name: Build and install
         run: |
           mkdir build && cd build
           cmake .. -G Ninja -DENABLE_TLS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
-          ninja -v
+          ninja -v install
       - name: Run tests
         working-directory: build
         run: .\tests\client_test.exe
@@ -288,9 +287,9 @@ jobs:
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-ninja
             mingw-w64-x86_64-libevent
-      - name: Build
+      - name: Build and install
         shell: msys2 {0}
         run: |
           mkdir build && cd build
           cmake .. -G Ninja
-          cmake --build .
+          ninja -v install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,11 @@ if (MSVC AND BUILD_SHARED_LIBS)
         CONFIGURATIONS Debug RelWithDebInfo)
 endif()
 
+# Install public headers
 install(DIRECTORY include/valkey
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        PATTERN "tls.h" EXCLUDE
+        PATTERN "rdma.h" EXCLUDE)
 
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/valkey.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
@@ -210,6 +213,10 @@ IF(ENABLE_TLS)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+    # Install public header
+    install(FILES include/valkey/tls.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/valkey)
+
     if (MSVC AND BUILD_SHARED_LIBS)
         INSTALL(FILES $<TARGET_PDB_FILE:valkey_tls>
             DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -269,6 +276,10 @@ if(ENABLE_RDMA)
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+    # Install public header
+    install(FILES include/valkey/rdma.h
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/valkey)
 
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/valkey_rdma.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
Filter out `tls.h` and `rdma.h` when installing the base library and let the options `ENABLE_TLS`/`ENABLE_RDMA` determine when to install each header.

Includes a CI change to perform an install on macOS and Windows.

Additional info:
CMake documentation for `install(DIRECTORY` describes that
`PATTERN will only match a complete file or directory name occurring at the end of the full path.`
    
