### PR TITLE
Add context accessor functions for error status and string

### DIFF
--- a/examples/async-ae.c
+++ b/examples/async-ae.c
@@ -23,7 +23,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         aeStop(loop);
         return;
     }
@@ -33,7 +33,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         aeStop(loop);
         return;
     }
@@ -46,9 +46,9 @@ int main(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-glib.c
+++ b/examples/async-glib.c
@@ -11,7 +11,7 @@ static void
 connect_cb(valkeyAsyncContext *ac G_GNUC_UNUSED,
            int status) {
     if (status != VALKEY_OK) {
-        g_printerr("Failed to connect: %s\n", ac->errstr);
+        g_printerr("Failed to connect: %s\n", valkeyAsyncGetErrorString(ac));
         g_main_loop_quit(mainloop);
     } else {
         g_printerr("Connected...\n");
@@ -22,7 +22,7 @@ static void
 disconnect_cb(const valkeyAsyncContext *ac G_GNUC_UNUSED,
               int status) {
     if (status != VALKEY_OK) {
-        g_error("Failed to disconnect: %s", ac->errstr);
+        g_error("Failed to disconnect: %s", valkeyAsyncGetErrorString(ac));
     } else {
         g_printerr("Disconnected...\n");
         g_main_loop_quit(mainloop);
@@ -48,8 +48,8 @@ gint main(gint argc G_GNUC_UNUSED, gchar *argv[] G_GNUC_UNUSED) {
     GSource *source;
 
     ac = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (ac->err) {
-        g_printerr("%s\n", ac->errstr);
+    if (valkeyAsyncGetError(ac)) {
+        g_printerr("%s\n", valkeyAsyncGetErrorString(ac));
         exit(EXIT_FAILURE);
     }
 

--- a/examples/async-ivykis.c
+++ b/examples/async-ivykis.c
@@ -20,7 +20,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -28,7 +28,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -42,9 +42,9 @@ int main(int argc, char **argv) {
     iv_init();
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-libev.c
+++ b/examples/async-libev.c
@@ -20,7 +20,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -28,7 +28,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -40,9 +40,9 @@ int main(int argc, char **argv) {
 #endif
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-libevent-tls.c
+++ b/examples/async-libevent-tls.c
@@ -21,7 +21,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -29,7 +29,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -70,9 +70,9 @@ int main(int argc, char **argv) {
     }
 
     valkeyAsyncContext *c = valkeyAsyncConnect(hostname, port);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
     if (valkeyInitiateTLSWithContext(&c->c, tls) != VALKEY_OK) {

--- a/examples/async-libevent.c
+++ b/examples/async-libevent.c
@@ -11,8 +11,8 @@
 void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
     if (reply == NULL) {
-        if (c->errstr) {
-            printf("errstr: %s\n", c->errstr);
+        if (valkeyAsyncGetErrorString(c)) {
+            printf("errstr: %s\n", valkeyAsyncGetErrorString(c));
         }
         return;
     }
@@ -24,7 +24,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -32,7 +32,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -51,9 +51,9 @@ int main(int argc, char **argv) {
     options.connect_timeout = &tv;
 
     valkeyAsyncContext *c = valkeyAsyncConnectWithOptions(&options);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-libhv.c
+++ b/examples/async-libhv.c
@@ -23,7 +23,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
 
     if (reply == NULL) {
-        printf("`DEBUG SLEEP` error: %s\n", c->errstr ? c->errstr : "unknown error");
+        printf("`DEBUG SLEEP` error: %s\n", valkeyAsyncGetErrorString(c) ? valkeyAsyncGetErrorString(c) : "unknown error");
         return;
     }
 
@@ -32,7 +32,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -40,7 +40,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -52,9 +52,9 @@ int main(int argc, char **argv) {
 #endif
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-libsdevent.c
+++ b/examples/async-libsdevent.c
@@ -14,7 +14,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
     if (reply == NULL) {
         /* The DEBUG SLEEP command will almost always fail, because we have set a 1 second timeout */
-        printf("`DEBUG SLEEP` error: %s\n", c->errstr ? c->errstr : "unknown error");
+        printf("`DEBUG SLEEP` error: %s\n", valkeyAsyncGetErrorString(c) ? valkeyAsyncGetErrorString(c) : "unknown error");
         return;
     }
     /* Disconnect after receiving the reply of DEBUG SLEEP (which will not)*/
@@ -24,7 +24,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
     if (reply == NULL) {
-        printf("`GET key` error: %s\n", c->errstr ? c->errstr : "unknown error");
+        printf("`GET key` error: %s\n", valkeyAsyncGetErrorString(c) ? valkeyAsyncGetErrorString(c) : "unknown error");
         return;
     }
     printf("`GET key` result: argv[%s]: %s\n", (char *)privdata, reply->str);
@@ -35,7 +35,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("connect error: %s\n", c->errstr);
+        printf("connect error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -43,7 +43,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("disconnect because of error: %s\n", c->errstr);
+        printf("disconnect because of error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
     sd_event_default(&event);
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
-        printf("Error: %s\n", c->errstr);
+    if (valkeyAsyncGetError(c)) {
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         valkeyAsyncFree(c);
         return 1;
     }

--- a/examples/async-libuv.c
+++ b/examples/async-libuv.c
@@ -14,7 +14,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
     if (reply == NULL) {
         /* The DEBUG SLEEP command will almost always fail, because we have set a 1 second timeout */
-        printf("`DEBUG SLEEP` error: %s\n", c->errstr ? c->errstr : "unknown error");
+        printf("`DEBUG SLEEP` error: %s\n", valkeyAsyncGetErrorString(c) ? valkeyAsyncGetErrorString(c) : "unknown error");
         return;
     }
     /* Disconnect after receiving the reply of DEBUG SLEEP (which will not)*/
@@ -24,7 +24,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
     if (reply == NULL) {
-        printf("`GET key` error: %s\n", c->errstr ? c->errstr : "unknown error");
+        printf("`GET key` error: %s\n", valkeyAsyncGetErrorString(c) ? valkeyAsyncGetErrorString(c) : "unknown error");
         return;
     }
     printf("`GET key` result: argv[%s]: %s\n", (char *)privdata, reply->str);
@@ -35,7 +35,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("connect error: %s\n", c->errstr);
+        printf("connect error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -43,7 +43,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("disconnect because of error: %s\n", c->errstr);
+        printf("disconnect because of error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -57,9 +57,9 @@ int main(int argc, char **argv) {
     uv_loop_t *loop = uv_default_loop();
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-macosx.c
+++ b/examples/async-macosx.c
@@ -50,7 +50,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -58,7 +58,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     CFRunLoopStop(CFRunLoopGetCurrent());
@@ -75,9 +75,9 @@ int main(int argc, char **argv) {
     }
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-poll.c
+++ b/examples/async-poll.c
@@ -23,7 +23,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         exit_loop = 1;
         return;
     }
@@ -34,7 +34,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     exit_loop = 1;
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
 
@@ -45,9 +45,9 @@ int main(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/async-valkeymoduleapi.c
+++ b/examples/async-valkeymoduleapi.c
@@ -11,7 +11,7 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
     if (reply == NULL) {
         /* The DEBUG SLEEP command will almost always fail, because we have set a 1 second timeout */
-        printf("`DEBUG SLEEP` error: %s\n", c->errstr ? c->errstr : "unknown error");
+        printf("`DEBUG SLEEP` error: %s\n", valkeyAsyncGetErrorString(c) ? valkeyAsyncGetErrorString(c) : "unknown error");
         return;
     }
     /* Disconnect after receiving the reply of DEBUG SLEEP (which will not)*/
@@ -21,8 +21,8 @@ void debugCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
     valkeyReply *reply = r;
     if (reply == NULL) {
-        if (c->errstr) {
-            printf("errstr: %s\n", c->errstr);
+        if (valkeyAsyncGetErrorString(c)) {
+            printf("errstr: %s\n", valkeyAsyncGetErrorString(c));
         }
         return;
     }
@@ -34,7 +34,7 @@ void getCallback(valkeyAsyncContext *c, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Connected...\n");
@@ -42,7 +42,7 @@ void connectCallback(valkeyAsyncContext *c, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *c, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return;
     }
     printf("Disconnected...\n");
@@ -64,9 +64,9 @@ int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int arg
     }
 
     valkeyAsyncContext *c = valkeyAsyncConnect("127.0.0.1", 6379);
-    if (c->err) {
+    if (valkeyAsyncGetError(c)) {
         /* Let *c leak for now... */
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(c));
         return 1;
     }
 

--- a/examples/blocking-push.c
+++ b/examples/blocking-push.c
@@ -60,8 +60,8 @@ static void assertReplyAndFree(valkeyContext *context, valkeyReply *reply, int t
 /* Switch to the RESP3 protocol and enable client tracking */
 static void enableClientTracking(valkeyContext *c) {
     valkeyReply *reply = valkeyCommand(c, "HELLO 3");
-    if (reply == NULL || c->err) {
-        panicAbort("NULL reply or server error (error: %s)", c->errstr);
+    if (reply == NULL || valkeyGetError(c)) {
+        panicAbort("NULL reply or server error (error: %s)", valkeyGetErrorString(c));
     }
 
     if (reply->type != VALKEY_REPLY_MAP) {
@@ -130,8 +130,8 @@ int main(int argc, char **argv) {
     o.push_cb = pushReplyHandler;
 
     c = valkeyConnectWithOptions(&o);
-    if (c == NULL || c->err)
-        panicAbort("Connection error:  %s", c ? c->errstr : "OOM");
+    if (c == NULL || valkeyGetError(c))
+        panicAbort("Connection error:  %s", c ? valkeyGetErrorString(c) : "OOM");
 
     /* Enable RESP3 and turn on client tracking */
     enableClientTracking(c);

--- a/examples/blocking-tls.c
+++ b/examples/blocking-tls.c
@@ -38,9 +38,9 @@ int main(int argc, char **argv) {
     options.connect_timeout = &tv;
     c = valkeyConnectWithOptions(&options);
 
-    if (c == NULL || c->err) {
+    if (c == NULL || valkeyGetError(c)) {
         if (c) {
-            printf("Connection error: %s\n", c->errstr);
+            printf("Connection error: %s\n", valkeyGetErrorString(c));
             valkeyFree(c);
         } else {
             printf("Connection error: can't allocate valkey context\n");
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
 
     if (valkeyInitiateTLSWithContext(c, tls) != VALKEY_OK) {
         printf("Couldn't initialize TLS!\n");
-        printf("Error: %s\n", c->errstr);
+        printf("Error: %s\n", valkeyGetErrorString(c));
         valkeyFree(c);
         exit(1);
     }

--- a/examples/blocking.c
+++ b/examples/blocking.c
@@ -38,7 +38,7 @@ static void example_argv_command(valkeyContext *c, size_t n) {
     reply = valkeyCommandArgv(
         c, n + 2, (const char **)argv, (const size_t *)argvlen);
 
-    if (reply == NULL || c->err) {
+    if (reply == NULL || valkeyGetError(c)) {
         fprintf(stderr, "Error:  Couldn't execute valkeyCommandArgv\n");
         exit(1);
     }
@@ -80,9 +80,9 @@ int main(int argc, char **argv) {
     } else {
         c = valkeyConnectWithTimeout(hostname, port, timeout);
     }
-    if (c == NULL || c->err) {
+    if (c == NULL || valkeyGetError(c)) {
         if (c) {
-            printf("Connection error: %s\n", c->errstr);
+            printf("Connection error: %s\n", valkeyGetErrorString(c));
             valkeyFree(c);
         } else {
             printf("Connection error: can't allocate valkey context\n");

--- a/examples/cluster-async-tls.c
+++ b/examples/cluster-async-tls.c
@@ -12,8 +12,8 @@
 void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (acc->err) {
-            printf("errstr: %s\n", acc->errstr);
+        if (valkeyClusterAsyncGetError(acc)) {
+            printf("errstr: %s\n", valkeyClusterAsyncGetErrorString(acc));
         }
         return;
     }
@@ -26,8 +26,8 @@ void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
 void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (acc->err) {
-            printf("errstr: %s\n", acc->errstr);
+        if (valkeyClusterAsyncGetError(acc)) {
+            printf("errstr: %s\n", valkeyClusterAsyncGetErrorString(acc));
         }
         return;
     }
@@ -36,7 +36,7 @@ void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *ac, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", ac->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(ac));
         return;
     }
 
@@ -45,7 +45,7 @@ void connectCallback(valkeyAsyncContext *ac, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", ac->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(ac));
         return;
     }
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
@@ -74,8 +74,8 @@ int main(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    if (acc == NULL || acc->err != 0) {
-        printf("Error: %s\n", acc ? acc->errstr : "OOM");
+    if (acc == NULL || valkeyClusterAsyncGetError(acc) != 0) {
+        printf("Error: %s\n", acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
         exit(-1);
     }
 
@@ -83,13 +83,13 @@ int main(void) {
     status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"THE_ID",
                                        "SET %s %s", "key", "value");
     if (status != VALKEY_OK) {
-        printf("error: err=%d errstr=%s\n", acc->err, acc->errstr);
+        printf("error: err=%d errstr=%s\n", valkeyClusterAsyncGetError(acc), valkeyClusterAsyncGetErrorString(acc));
     }
 
     status = valkeyClusterAsyncCommand(acc, getCallback, (char *)"THE_ID",
                                        "GET %s", "key");
     if (status != VALKEY_OK) {
-        printf("error: err=%d errstr=%s\n", acc->err, acc->errstr);
+        printf("error: err=%d errstr=%s\n", valkeyClusterAsyncGetError(acc), valkeyClusterAsyncGetErrorString(acc));
     }
 
     printf("Dispatch..\n");

--- a/examples/cluster-async-tls.c
+++ b/examples/cluster-async-tls.c
@@ -9,25 +9,25 @@
 
 #define CLUSTER_NODE_TLS "127.0.0.1:7300"
 
-void getCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
+void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (cc->err) {
-            printf("errstr: %s\n", cc->errstr);
+        if (acc->err) {
+            printf("errstr: %s\n", acc->errstr);
         }
         return;
     }
     printf("privdata: %s reply: %s\n", (char *)privdata, reply->str);
 
     /* Disconnect after receiving the reply to GET */
-    valkeyClusterAsyncDisconnect(cc);
+    valkeyClusterAsyncDisconnect(acc);
 }
 
-void setCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
+void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (cc->err) {
-            printf("errstr: %s\n", cc->errstr);
+        if (acc->err) {
+            printf("errstr: %s\n", acc->errstr);
         }
         return;
     }

--- a/examples/cluster-async.c
+++ b/examples/cluster-async.c
@@ -5,25 +5,25 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-void getCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
+void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (cc->err) {
-            printf("errstr: %s\n", cc->errstr);
+        if (acc->err) {
+            printf("errstr: %s\n", acc->errstr);
         }
         return;
     }
     printf("privdata: %s reply: %s\n", (char *)privdata, reply->str);
 
     /* Disconnect after receiving the reply to GET */
-    valkeyClusterAsyncDisconnect(cc);
+    valkeyClusterAsyncDisconnect(acc);
 }
 
-void setCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
+void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (cc->err) {
-            printf("errstr: %s\n", cc->errstr);
+        if (acc->err) {
+            printf("errstr: %s\n", acc->errstr);
         }
         return;
     }

--- a/examples/cluster-async.c
+++ b/examples/cluster-async.c
@@ -8,8 +8,8 @@
 void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (acc->err) {
-            printf("errstr: %s\n", acc->errstr);
+        if (valkeyClusterAsyncGetError(acc)) {
+            printf("errstr: %s\n", valkeyClusterAsyncGetErrorString(acc));
         }
         return;
     }
@@ -22,8 +22,8 @@ void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
 void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     if (reply == NULL) {
-        if (acc->err) {
-            printf("errstr: %s\n", acc->errstr);
+        if (valkeyClusterAsyncGetError(acc)) {
+            printf("errstr: %s\n", valkeyClusterAsyncGetErrorString(acc));
         }
         return;
     }
@@ -32,7 +32,7 @@ void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
 
 void connectCallback(valkeyAsyncContext *ac, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", ac->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(ac));
         return;
     }
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
@@ -40,7 +40,7 @@ void connectCallback(valkeyAsyncContext *ac, int status) {
 
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     if (status != VALKEY_OK) {
-        printf("Error: %s\n", ac->errstr);
+        printf("Error: %s\n", valkeyAsyncGetErrorString(ac));
         return;
     }
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
@@ -60,8 +60,8 @@ int main(void) {
     if (!acc) {
         printf("Error: Allocation failure\n");
         exit(-1);
-    } else if (acc->err) {
-        printf("Error: %s\n", acc->errstr);
+    } else if (valkeyClusterAsyncGetError(acc)) {
+        printf("Error: %s\n", valkeyClusterAsyncGetErrorString(acc));
         // handle error
         exit(-1);
     }
@@ -70,25 +70,25 @@ int main(void) {
     status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"THE_ID",
                                        "SET %s %s", "key", "value");
     if (status != VALKEY_OK) {
-        printf("error: err=%d errstr=%s\n", acc->err, acc->errstr);
+        printf("error: err=%d errstr=%s\n", valkeyClusterAsyncGetError(acc), valkeyClusterAsyncGetErrorString(acc));
     }
 
     status = valkeyClusterAsyncCommand(acc, getCallback, (char *)"THE_ID",
                                        "GET %s", "key");
     if (status != VALKEY_OK) {
-        printf("error: err=%d errstr=%s\n", acc->err, acc->errstr);
+        printf("error: err=%d errstr=%s\n", valkeyClusterAsyncGetError(acc), valkeyClusterAsyncGetErrorString(acc));
     }
 
     status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"THE_ID",
                                        "SET %s %s", "key2", "value2");
     if (status != VALKEY_OK) {
-        printf("error: err=%d errstr=%s\n", acc->err, acc->errstr);
+        printf("error: err=%d errstr=%s\n", valkeyClusterAsyncGetError(acc), valkeyClusterAsyncGetErrorString(acc));
     }
 
     status = valkeyClusterAsyncCommand(acc, getCallback, (char *)"THE_ID",
                                        "GET %s", "key2");
     if (status != VALKEY_OK) {
-        printf("error: err=%d errstr=%s\n", acc->err, acc->errstr);
+        printf("error: err=%d errstr=%s\n", valkeyClusterAsyncGetError(acc), valkeyClusterAsyncGetErrorString(acc));
     }
 
     printf("Dispatch..\n");

--- a/examples/cluster-clientside-caching-async.c
+++ b/examples/cluster-clientside-caching-async.c
@@ -150,8 +150,8 @@ int main(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    if (acc == NULL || acc->err != 0) {
-        printf("Connect error: %s\n", acc ? acc->errstr : "OOM");
+    if (acc == NULL || valkeyClusterAsyncGetError(acc) != 0) {
+        printf("Connect error: %s\n", acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
         exit(2);
     }
 

--- a/examples/cluster-simple.c
+++ b/examples/cluster-simple.c
@@ -14,8 +14,8 @@ int main(void) {
     if (!cc) {
         printf("Error: Allocation failure\n");
         exit(-1);
-    } else if (cc->err) {
-        printf("Error: %s\n", cc->errstr);
+    } else if (valkeyClusterGetError(cc)) {
+        printf("Error: %s\n", valkeyClusterGetErrorString(cc));
         // handle error
         exit(-1);
     }

--- a/examples/cluster-tls.c
+++ b/examples/cluster-tls.c
@@ -30,15 +30,15 @@ int main(void) {
     if (!cc) {
         printf("Error: Allocation failure\n");
         exit(-1);
-    } else if (cc->err) {
-        printf("Error: %s\n", cc->errstr);
+    } else if (valkeyClusterGetError(cc)) {
+        printf("Error: %s\n", valkeyClusterGetErrorString(cc));
         // handle error
         exit(-1);
     }
 
     valkeyReply *reply = valkeyClusterCommand(cc, "SET %s %s", "key", "value");
     if (!reply) {
-        printf("Reply missing: %s\n", cc->errstr);
+        printf("Reply missing: %s\n", valkeyClusterGetErrorString(cc));
         exit(-1);
     }
     printf("SET: %s\n", reply->str);
@@ -46,7 +46,7 @@ int main(void) {
 
     valkeyReply *reply2 = valkeyClusterCommand(cc, "GET %s", "key");
     if (!reply2) {
-        printf("Reply missing: %s\n", cc->errstr);
+        printf("Reply missing: %s\n", valkeyClusterGetErrorString(cc));
         exit(-1);
     }
     printf("GET: %s\n", reply2->str);

--- a/include/valkey/async.h
+++ b/include/valkey/async.h
@@ -137,6 +137,9 @@ int valkeyAsyncSetTimeout(valkeyAsyncContext *ac, struct timeval tv);
 void valkeyAsyncDisconnect(valkeyAsyncContext *ac);
 void valkeyAsyncFree(valkeyAsyncContext *ac);
 
+int valkeyAsyncGetError(const valkeyAsyncContext *ac);
+const char *valkeyAsyncGetErrorString(const valkeyAsyncContext *ac);
+
 /* Handle read/write events */
 void valkeyAsyncHandleRead(valkeyAsyncContext *ac);
 void valkeyAsyncHandleWrite(valkeyAsyncContext *ac);

--- a/include/valkey/cluster.h
+++ b/include/valkey/cluster.h
@@ -217,6 +217,9 @@ valkeyClusterContext *valkeyClusterConnect(const char *addrs);
 valkeyClusterContext *valkeyClusterConnectWithTimeout(const char *addrs, const struct timeval tv);
 void valkeyClusterFree(valkeyClusterContext *cc);
 
+int valkeyClusterGetError(const valkeyClusterContext *cc);
+const char *valkeyClusterGetErrorString(const valkeyClusterContext *cc);
+
 /* Options configurable in runtime. */
 int valkeyClusterSetOptionTimeout(valkeyClusterContext *cc, const struct timeval tv);
 
@@ -286,6 +289,9 @@ valkeyContext *valkeyClusterGetValkeyContext(valkeyClusterContext *cc,
 valkeyClusterAsyncContext *valkeyClusterAsyncConnectWithOptions(const valkeyClusterOptions *options);
 void valkeyClusterAsyncDisconnect(valkeyClusterAsyncContext *acc);
 void valkeyClusterAsyncFree(valkeyClusterAsyncContext *acc);
+
+int valkeyClusterAsyncGetError(const valkeyClusterAsyncContext *acc);
+const char *valkeyClusterAsyncGetErrorString(const valkeyClusterAsyncContext *acc);
 
 /* Commands */
 int valkeyClusterAsyncCommand(valkeyClusterAsyncContext *acc,

--- a/include/valkey/cluster.h
+++ b/include/valkey/cluster.h
@@ -219,6 +219,7 @@ void valkeyClusterFree(valkeyClusterContext *cc);
 
 int valkeyClusterGetError(const valkeyClusterContext *cc);
 const char *valkeyClusterGetErrorString(const valkeyClusterContext *cc);
+void valkeyClusterClearError(valkeyClusterContext *cc);
 
 /* Options configurable in runtime. */
 int valkeyClusterSetOptionTimeout(valkeyClusterContext *cc, const struct timeval tv);
@@ -292,6 +293,7 @@ void valkeyClusterAsyncFree(valkeyClusterAsyncContext *acc);
 
 int valkeyClusterAsyncGetError(const valkeyClusterAsyncContext *acc);
 const char *valkeyClusterAsyncGetErrorString(const valkeyClusterAsyncContext *acc);
+void valkeyClusterAsyncClearError(valkeyClusterAsyncContext *acc);
 
 /* Commands */
 int valkeyClusterAsyncCommand(valkeyClusterAsyncContext *acc,

--- a/include/valkey/valkey.h
+++ b/include/valkey/valkey.h
@@ -348,6 +348,9 @@ int valkeyEnableKeepAlive(valkeyContext *c);
 int valkeyEnableKeepAliveWithInterval(valkeyContext *c, int interval);
 int valkeySetTcpUserTimeout(valkeyContext *c, unsigned int timeout);
 
+int valkeyGetError(const valkeyContext *c);
+const char *valkeyGetErrorString(const valkeyContext *c);
+
 void valkeyFree(valkeyContext *c);
 valkeyFD valkeyFreeKeepFd(valkeyContext *c);
 int valkeyBufferRead(valkeyContext *c);

--- a/src/async.c
+++ b/src/async.c
@@ -408,6 +408,16 @@ void valkeyAsyncFree(valkeyAsyncContext *ac) {
         valkeyAsyncFreeInternal(ac);
 }
 
+/* Get context error status (VALKEY_OK or VALKEY_ERR_x). */
+int valkeyAsyncGetError(const valkeyAsyncContext *ac) {
+    return ac->err;
+}
+
+/* Get context error description. */
+const char *valkeyAsyncGetErrorString(const valkeyAsyncContext *ac) {
+    return ac->errstr;
+}
+
 /* Helper function to make the disconnect happen and clean up. */
 void valkeyAsyncDisconnectInternal(valkeyAsyncContext *ac) {
     valkeyContext *c = &(ac->c);

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -218,7 +218,7 @@ static void valkeyClusterSetError(valkeyClusterContext *cc, int type,
     }
 }
 
-static inline void valkeyClusterClearError(valkeyClusterContext *cc) {
+void valkeyClusterClearError(valkeyClusterContext *cc) {
     cc->err = 0;
     cc->errstr[0] = '\0';
 }
@@ -2660,7 +2660,7 @@ static void valkeyClusterAsyncSetError(valkeyClusterAsyncContext *acc, int type,
     acc->err = acc->cc.err;
 }
 
-static inline void valkeyClusterAsyncClearError(valkeyClusterAsyncContext *acc) {
+void valkeyClusterAsyncClearError(valkeyClusterAsyncContext *acc) {
     valkeyClusterClearError(&acc->cc);
     acc->err = acc->cc.err;
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -1640,6 +1640,16 @@ int valkeyClusterSetOptionTimeout(valkeyClusterContext *cc,
     return VALKEY_OK;
 }
 
+/* Get context error status (VALKEY_OK or VALKEY_ERR_x). */
+int valkeyClusterGetError(const valkeyClusterContext *cc) {
+    return cc->err;
+}
+
+/* Get context error description. */
+const char *valkeyClusterGetErrorString(const valkeyClusterContext *cc) {
+    return cc->errstr;
+}
+
 valkeyContext *valkeyClusterGetValkeyContext(valkeyClusterContext *cc,
                                              valkeyClusterNode *node) {
     valkeyContext *c = NULL;
@@ -2833,6 +2843,16 @@ static int valkeyClusterAsyncConnect(valkeyClusterAsyncContext *acc) {
     }
     /* Use non-blocking initial slotmap update. */
     return updateSlotMapAsync(acc, NULL /*any node*/);
+}
+
+/* Get context error status (VALKEY_OK or VALKEY_ERR_x). */
+int valkeyClusterAsyncGetError(const valkeyClusterAsyncContext *acc) {
+    return acc->err;
+}
+
+/* Get context error description. */
+const char *valkeyClusterAsyncGetErrorString(const valkeyClusterAsyncContext *acc) {
+    return acc->errstr;
 }
 
 /* Reply callback function for CLUSTER SLOTS */

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -996,6 +996,16 @@ valkeyPushFn *valkeySetPushCallback(valkeyContext *c, valkeyPushFn *fn) {
     return old;
 }
 
+/* Get context error status (VALKEY_OK or VALKEY_ERR_x). */
+int valkeyGetError(const valkeyContext *c) {
+    return c->err;
+}
+
+/* Get context error description. */
+const char *valkeyGetErrorString(const valkeyContext *c) {
+    return c->errstr;
+}
+
 /* Use this function to handle a read event on the descriptor. It will try
  * and read some bytes from the socket and feed them to the reply parser.
  *

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -99,8 +99,8 @@ int main(int argc, char **argv) {
     }
 
     valkeyClusterContext *cc = valkeyClusterConnectWithOptions(&options);
-    if (cc == NULL || cc->err) {
-        printf("Connect error: %s\n", cc ? cc->errstr : "OOM");
+    if (cc == NULL || valkeyClusterGetError(cc)) {
+        printf("Connect error: %s\n", cc ? valkeyClusterGetErrorString(cc) : "OOM");
         exit(2);
     }
 
@@ -129,8 +129,8 @@ int main(int argc, char **argv) {
             while ((node = valkeyClusterNodeNext(&ni)) != NULL) {
                 valkeyReply *reply =
                     valkeyClusterCommandToNode(cc, node, command);
-                if (!reply || cc->err) {
-                    printf("error: %s\n", cc->errstr);
+                if (!reply || valkeyClusterGetError(cc)) {
+                    printf("error: %s\n", valkeyClusterGetErrorString(cc));
                 } else {
                     printReply(reply);
                 }
@@ -142,8 +142,8 @@ int main(int argc, char **argv) {
             }
         } else {
             valkeyReply *reply = valkeyClusterCommand(cc, command);
-            if (!reply || cc->err) {
-                printf("error: %s\n", cc->errstr);
+            if (!reply || valkeyClusterGetError(cc)) {
+                printf("error: %s\n", valkeyClusterGetErrorString(cc));
             } else {
                 printReply(reply);
             }

--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -83,8 +83,8 @@ void replyCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     intptr_t cmd_id = (intptr_t)privdata; /* Id to corresponding cmd */
 
     if (reply == NULL) {
-        if (acc->err) {
-            printf("error: %s\n", acc->errstr);
+        if (valkeyClusterAsyncGetError(acc)) {
+            printf("error: %s\n", valkeyClusterAsyncGetErrorString(acc));
         } else {
             printf("unknown error\n");
         }
@@ -163,7 +163,7 @@ void sendNextCommand(evutil_socket_t fd, short kind, void *arg) {
                 int status = valkeyClusterAsyncCommandToNode(
                     acc, node, replyCallback, (void *)((intptr_t)num_running),
                     cmd);
-                ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+                ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
                 num_running++;
             }
         } else {
@@ -172,7 +172,7 @@ void sendNextCommand(evutil_socket_t fd, short kind, void *arg) {
             if (status == VALKEY_OK) {
                 num_running++;
             } else {
-                printf("error: %s\n", acc->errstr);
+                printf("error: %s\n", valkeyClusterAsyncGetErrorString(acc));
 
                 /* Schedule a read from stdin and handle next command. */
                 struct timeval timeout = {0, 10};
@@ -286,8 +286,8 @@ int main(int argc, char **argv) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    if (acc == NULL || acc->err != 0) {
-        printf("Connect error: %s\n", acc ? acc->errstr : "OOM");
+    if (acc == NULL || valkeyClusterAsyncGetError(acc) != 0) {
+        printf("Connect error: %s\n", acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
         exit(2);
     }
 

--- a/tests/ct_async.c
+++ b/tests/ct_async.c
@@ -11,7 +11,7 @@
 void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 
     /* Disconnect after receiving the first reply to GET */
     valkeyClusterAsyncDisconnect(acc);
@@ -20,16 +20,16 @@ void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
 void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 }
 
 void connectCallback(valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
@@ -45,20 +45,20 @@ void eventCallback(const valkeyClusterContext *cc, int event, void *privdata) {
         int status;
         status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"ID",
                                            "SET key12345 value");
-        ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+        ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
         /* This command will trigger a disconnect in its reply callback. */
         status = valkeyClusterAsyncCommand(acc, getCallback, (char *)"ID",
                                            "GET key12345");
-        ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+        ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
         status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"ID",
                                            "SET key23456 value2");
-        ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+        ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
         status = valkeyClusterAsyncCommand(acc, getCallback, (char *)"ID",
                                            "GET key23456");
-        ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+        ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
     }
 }
 
@@ -73,7 +73,7 @@ int main(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    assert(acc && acc->err == 0);
+    assert(acc && valkeyClusterAsyncGetError(acc) == 0);
 
     event_base_dispatch(base);
 

--- a/tests/ct_async_glib.c
+++ b/tests/ct_async_glib.c
@@ -11,13 +11,13 @@ static GMainLoop *mainloop;
 void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 }
 
 void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 
     /* Disconnect after receiving the first reply to GET */
     valkeyClusterAsyncDisconnect(acc);
@@ -25,12 +25,12 @@ void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
 }
 
 void connectCallback(valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
@@ -50,14 +50,14 @@ int main(int argc, char **argv) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
     assert(acc);
-    ASSERT_MSG(acc->err == 0, acc->errstr);
+    ASSERT_MSG(valkeyClusterAsyncGetError(acc) == 0, valkeyClusterAsyncGetErrorString(acc));
 
     int status;
     status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"id", "SET key value");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     status = valkeyClusterAsyncCommand(acc, getCallback, (char *)"id", "GET key");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     g_main_loop_run(mainloop);
 

--- a/tests/ct_async_libev.c
+++ b/tests/ct_async_libev.c
@@ -9,25 +9,25 @@
 void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 }
 
 void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 
     /* Disconnect after receiving the first reply to GET */
     valkeyClusterAsyncDisconnect(acc);
 }
 
 void connectCallback(valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
@@ -44,16 +44,16 @@ int main(int argc, char **argv) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
     assert(acc);
-    ASSERT_MSG(acc->err == 0, acc->errstr);
+    ASSERT_MSG(valkeyClusterAsyncGetError(acc) == 0, valkeyClusterAsyncGetErrorString(acc));
 
     int status;
     status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"ID",
                                        "SET key value");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     status =
         valkeyClusterAsyncCommand(acc, getCallback, (char *)"ID", "GET key");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     ev_loop(EV_DEFAULT_ 0);
 

--- a/tests/ct_async_libuv.c
+++ b/tests/ct_async_libuv.c
@@ -10,25 +10,25 @@
 void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 }
 
 void getCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     UNUSED(privdata);
     valkeyReply *reply = (valkeyReply *)r;
-    ASSERT_MSG(reply != NULL, acc->errstr);
+    ASSERT_MSG(reply != NULL, valkeyClusterAsyncGetErrorString(acc));
 
     /* Disconnect after receiving the first reply to GET */
     valkeyClusterAsyncDisconnect(acc);
 }
 
 void connectCallback(valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Connected to %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
-    ASSERT_MSG(status == VALKEY_OK, ac->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyAsyncGetErrorString(ac));
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 }
 
@@ -47,16 +47,16 @@ int main(int argc, char **argv) {
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
     assert(acc);
-    ASSERT_MSG(acc->err == 0, acc->errstr);
+    ASSERT_MSG(valkeyClusterAsyncGetError(acc) == 0, valkeyClusterAsyncGetErrorString(acc));
 
     int status;
     status = valkeyClusterAsyncCommand(acc, setCallback, (char *)"ID",
                                        "SET key value");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     status =
         valkeyClusterAsyncCommand(acc, getCallback, (char *)"ID", "GET key");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     uv_run(loop, UV_RUN_DEFAULT);
 

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -467,7 +467,7 @@ int main(void) {
     options.connect_timeout = &timeout;
 
     valkeyClusterContext *cc = valkeyClusterConnectWithOptions(&options);
-    ASSERT_MSG(cc && cc->err == 0, cc ? cc->errstr : "OOM");
+    ASSERT_MSG(cc && valkeyClusterGetError(cc) == 0, cc ? valkeyClusterGetErrorString(cc) : "OOM");
     load_valkey_version(cc);
 
     test_bitfield(cc);

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -283,12 +283,12 @@ void disconnectCallback(const valkeyAsyncContext *ac, int status) {
 }
 
 // Callback for async commands, verifies the valkeyReply
-void commandCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
+void commandCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     ExpectedResult *expect = (ExpectedResult *)privdata;
     if (expect->noreply) {
         assert(reply == NULL);
-        assert(strcmp(cc->errstr, expect->errstr) == 0);
+        assert(strcmp(acc->errstr, expect->errstr) == 0);
     } else {
         assert(reply != NULL);
         assert(reply->type == expect->type);
@@ -301,7 +301,7 @@ void commandCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
         }
     }
     if (expect->disconnect)
-        valkeyClusterAsyncDisconnect(cc);
+        valkeyClusterAsyncDisconnect(acc);
 }
 
 // Connecting to a password protected cluster using

--- a/tests/ct_connection_ipv6.c
+++ b/tests/ct_connection_ipv6.c
@@ -17,7 +17,7 @@ void test_successful_ipv6_connection(void) {
     options.connect_timeout = &timeout;
 
     valkeyClusterContext *cc = valkeyClusterConnectWithOptions(&options);
-    ASSERT_MSG(cc && cc->err == 0, cc ? cc->errstr : "OOM");
+    ASSERT_MSG(cc && valkeyClusterGetError(cc) == 0, cc ? valkeyClusterGetErrorString(cc) : "OOM");
 
     valkeyReply *reply;
     reply = (valkeyReply *)valkeyClusterCommand(cc, "SET key_ipv6 value");

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -77,15 +77,13 @@ static void *vk_realloc_fail(void *ptr, size_t size) {
 void prepare_allocation_test(valkeyClusterContext *cc,
                              int _successfulAllocations) {
     successfulAllocations = _successfulAllocations;
-    cc->err = 0;
-    memset(cc->errstr, '\0', strlen(cc->errstr));
+    valkeyClusterClearError(cc);
 }
 
 void prepare_allocation_test_async(valkeyClusterAsyncContext *acc,
                                    int _successfulAllocations) {
     successfulAllocations = _successfulAllocations;
-    acc->err = 0;
-    memset(acc->errstr, '\0', strlen(acc->errstr));
+    valkeyClusterAsyncClearError(acc);
 }
 
 /* Helper */

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -131,14 +131,14 @@ void test_alloc_failure_handling(void) {
             successfulAllocations = i;
             cc = valkeyClusterConnectWithOptions(&options);
             assert(cc);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
             valkeyClusterFree(cc);
         }
         // Skip iteration 100 to 159 since sdscatfmt give leak warnings during OOM.
 
         successfulAllocations = 160;
         cc = valkeyClusterConnectWithOptions(&options);
-        assert(cc && cc->err == 0);
+        assert(cc && valkeyClusterGetError(cc) == 0);
     }
 
     // Command
@@ -150,7 +150,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             reply = (valkeyReply *)valkeyClusterCommand(cc, cmd);
             assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
         }
 
         prepare_allocation_test(cc, 33);
@@ -172,7 +172,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             reply = valkeyClusterCommandToNode(cc, node, cmd);
             assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
         }
 
         // Successful command
@@ -191,7 +191,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             result = valkeyClusterAppendCommand(cc, cmd);
             assert(result == VALKEY_ERR);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
 
             valkeyClusterReset(cc);
         }
@@ -206,7 +206,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             result = valkeyClusterGetReply(cc, (void *)&reply);
             assert(result == VALKEY_ERR);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
 
             valkeyClusterReset(cc);
         }
@@ -235,7 +235,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             result = valkeyClusterAppendCommandToNode(cc, node, cmd);
             assert(result == VALKEY_ERR);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
 
             valkeyClusterReset(cc);
         }
@@ -250,7 +250,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             result = valkeyClusterGetReply(cc, (void *)&reply);
             assert(result == VALKEY_ERR);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
 
             valkeyClusterReset(cc);
         }
@@ -320,7 +320,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             reply = valkeyClusterCommand(cc, "GET foo");
             assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
         }
 
         /* Test ASK reply handling without OOM */
@@ -349,7 +349,7 @@ void test_alloc_failure_handling(void) {
             prepare_allocation_test(cc, i);
             reply = valkeyClusterCommand(cc, "GET foo");
             assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterGetErrorString(cc), "Out of memory");
         }
 
         /* Test MOVED reply handling without OOM */
@@ -466,14 +466,14 @@ void test_alloc_failure_handling_async(void) {
             successfulAllocations = i;
             acc = valkeyClusterAsyncConnectWithOptions(&options);
             assert(acc != NULL);
-            ASSERT_STR_EQ(acc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterAsyncGetErrorString(acc), "Out of memory");
             valkeyClusterAsyncFree(acc);
         }
         // Skip iteration 100 to 156 since sdscatfmt give leak warnings during OOM.
 
         successfulAllocations = 157;
         acc = valkeyClusterAsyncConnectWithOptions(&options);
-        assert(acc && acc->err == 0);
+        assert(acc && valkeyClusterAsyncGetError(acc) == 0);
     }
 
     // Async command 1
@@ -486,15 +486,15 @@ void test_alloc_failure_handling_async(void) {
             result = valkeyClusterAsyncCommand(acc, commandCallback, &r1, cmd1);
             assert(result == VALKEY_ERR);
             if (i != 34) {
-                ASSERT_STR_EQ(acc->errstr, "Out of memory");
+                ASSERT_STR_EQ(valkeyClusterAsyncGetErrorString(acc), "Out of memory");
             } else {
-                ASSERT_STR_EQ(acc->errstr, "Failed to attach event adapter");
+                ASSERT_STR_EQ(valkeyClusterAsyncGetErrorString(acc), "Failed to attach event adapter");
             }
         }
 
         prepare_allocation_test_async(acc, 35);
         result = valkeyClusterAsyncCommand(acc, commandCallback, &r1, cmd1);
-        ASSERT_MSG(result == VALKEY_OK, acc->errstr);
+        ASSERT_MSG(result == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
     }
 
     // Async command 2
@@ -507,14 +507,14 @@ void test_alloc_failure_handling_async(void) {
             prepare_allocation_test_async(acc, i);
             result = valkeyClusterAsyncCommand(acc, commandCallback, &r2, cmd2);
             assert(result == VALKEY_ERR);
-            ASSERT_STR_EQ(acc->errstr, "Out of memory");
+            ASSERT_STR_EQ(valkeyClusterAsyncGetErrorString(acc), "Out of memory");
         }
 
         /* Skip iteration 12, errstr not set by libvalkey when valkeyFormatSdsCommandArgv() fails. */
 
         prepare_allocation_test_async(acc, 13);
         result = valkeyClusterAsyncCommand(acc, commandCallback, &r2, cmd2);
-        ASSERT_MSG(result == VALKEY_OK, acc->errstr);
+        ASSERT_MSG(result == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
     }
 
     prepare_allocation_test_async(acc, 7);

--- a/tests/ct_pipeline.c
+++ b/tests/ct_pipeline.c
@@ -16,19 +16,19 @@ void test_pipeline(void) {
     options.initial_nodes = CLUSTER_NODE;
 
     valkeyClusterContext *cc = valkeyClusterConnectWithOptions(&options);
-    ASSERT_MSG(cc && cc->err == 0, cc ? cc->errstr : "OOM");
+    ASSERT_MSG(cc && valkeyClusterGetError(cc) == 0, cc ? valkeyClusterGetErrorString(cc) : "OOM");
 
     int status;
     status = valkeyClusterAppendCommand(cc, "SET foo one");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     status = valkeyClusterAppendCommand(cc, "SET bar two");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     status = valkeyClusterAppendCommand(cc, "GET foo");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     status = valkeyClusterAppendCommand(cc, "GET bar");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     status = valkeyClusterAppendCommand(cc, "SUNION a b");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
 
     valkeyReply *reply;
     valkeyClusterGetReply(cc, (void *)&reply); // reply for: SET foo one
@@ -102,33 +102,33 @@ void test_async_pipeline(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    ASSERT_MSG(acc && acc->err == 0, acc ? acc->errstr : "OOM");
+    ASSERT_MSG(acc && valkeyClusterAsyncGetError(acc) == 0, acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
 
     int status;
     ExpectedResult r1 = {.type = VALKEY_REPLY_STATUS, .str = "OK"};
     status =
         valkeyClusterAsyncCommand(acc, commandCallback, &r1, "SET foo six");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     ExpectedResult r2 = {.type = VALKEY_REPLY_STATUS, .str = "OK"};
     status =
         valkeyClusterAsyncCommand(acc, commandCallback, &r2, "SET bar ten");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     ExpectedResult r3 = {.type = VALKEY_REPLY_STRING, .str = "six"};
     status = valkeyClusterAsyncCommand(acc, commandCallback, &r3, "GET foo");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     ExpectedResult r4 = {.type = VALKEY_REPLY_STRING, .str = "ten"};
     status = valkeyClusterAsyncCommand(acc, commandCallback, &r4, "GET bar");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     ExpectedResult r5 = {
         .type = VALKEY_REPLY_ERROR,
         .str = "CROSSSLOT Keys in request don't hash to the same slot",
         .disconnect = true};
     status = valkeyClusterAsyncCommand(acc, commandCallback, &r5, "SUNION a b");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     event_base_dispatch(base);
 

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -287,12 +287,12 @@ void disconnectCallback(const valkeyAsyncContext *ac, int status) {
 }
 
 // Callback for async commands, verifies the valkeyReply
-void commandCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
+void commandCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     valkeyReply *reply = (valkeyReply *)r;
     ExpectedResult *expect = (ExpectedResult *)privdata;
     if (expect->noreply) {
         assert(reply == NULL);
-        assert(strcmp(cc->errstr, expect->errstr) == 0);
+        assert(strcmp(acc->errstr, expect->errstr) == 0);
     } else {
         assert(reply != NULL);
         assert(reply->type == expect->type);
@@ -314,7 +314,7 @@ void commandCallback(valkeyClusterAsyncContext *cc, void *r, void *privdata) {
         }
     }
     if (expect->disconnect)
-        valkeyClusterAsyncDisconnect(cc);
+        valkeyClusterAsyncDisconnect(acc);
 }
 
 void test_async_to_single_node(void) {

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -185,7 +185,7 @@ void test_pipeline_to_single_node(valkeyClusterContext *cc) {
     assert(node);
 
     status = valkeyClusterAppendCommandToNode(cc, node, "DBSIZE");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
 
     // Trigger send of pipeline commands
     valkeyClusterGetReply(cc, (void *)&reply);
@@ -202,7 +202,7 @@ void test_pipeline_to_all_nodes(valkeyClusterContext *cc) {
     valkeyClusterNode *node;
     while ((node = valkeyClusterNodeNext(&ni)) != NULL) {
         int status = valkeyClusterAppendCommandToNode(cc, node, "DBSIZE");
-        ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+        ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     }
 
     // Get replies from 3 node cluster
@@ -234,13 +234,13 @@ void test_pipeline_transaction(valkeyClusterContext *cc) {
     assert(node);
 
     status = valkeyClusterAppendCommandToNode(cc, node, "MULTI");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     status = valkeyClusterAppendCommandToNode(cc, node, "SET foo 199");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     status = valkeyClusterAppendCommandToNode(cc, node, "INCR foo");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
     status = valkeyClusterAppendCommandToNode(cc, node, "EXEC");
-    ASSERT_MSG(status == VALKEY_OK, cc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterGetErrorString(cc));
 
     // Trigger send of pipeline commands
     {
@@ -292,7 +292,7 @@ void commandCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     ExpectedResult *expect = (ExpectedResult *)privdata;
     if (expect->noreply) {
         assert(reply == NULL);
-        assert(strcmp(acc->errstr, expect->errstr) == 0);
+        assert(strcmp(valkeyClusterAsyncGetErrorString(acc), expect->errstr) == 0);
     } else {
         assert(reply != NULL);
         assert(reply->type == expect->type);
@@ -329,7 +329,7 @@ void test_async_to_single_node(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    ASSERT_MSG(acc && acc->err == 0, acc ? acc->errstr : "OOM");
+    ASSERT_MSG(acc && valkeyClusterAsyncGetError(acc) == 0, acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
 
     valkeyClusterNodeIterator ni;
     valkeyClusterInitNodeIterator(&ni, &acc->cc);
@@ -340,7 +340,7 @@ void test_async_to_single_node(void) {
     ExpectedResult r1 = {.type = VALKEY_REPLY_INTEGER, .disconnect = true};
     status = valkeyClusterAsyncCommandToNode(acc, node, commandCallback, &r1,
                                              "DBSIZE");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     event_base_dispatch(base);
 
@@ -360,7 +360,7 @@ void test_async_formatted_to_single_node(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    ASSERT_MSG(acc && acc->err == 0, acc ? acc->errstr : "OOM");
+    ASSERT_MSG(acc && valkeyClusterAsyncGetError(acc) == 0, acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
 
     valkeyClusterNodeIterator ni;
     valkeyClusterInitNodeIterator(&ni, &acc->cc);
@@ -372,7 +372,7 @@ void test_async_formatted_to_single_node(void) {
     char command[] = "*1\r\n$6\r\nDBSIZE\r\n";
     status = valkeyClusterAsyncFormattedCommandToNode(
         acc, node, commandCallback, &r1, command, strlen(command));
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     event_base_dispatch(base);
 
@@ -392,7 +392,7 @@ void test_async_command_argv_to_single_node(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    ASSERT_MSG(acc && acc->err == 0, acc ? acc->errstr : "OOM");
+    ASSERT_MSG(acc && valkeyClusterAsyncGetError(acc) == 0, acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
 
     valkeyClusterNodeIterator ni;
     valkeyClusterInitNodeIterator(&ni, &acc->cc);
@@ -404,7 +404,7 @@ void test_async_command_argv_to_single_node(void) {
     status = valkeyClusterAsyncCommandArgvToNode(
         acc, node, commandCallback, &r1, 1, (const char *[]){"DBSIZE"},
         (size_t[]){6});
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     event_base_dispatch(base);
 
@@ -424,7 +424,7 @@ void test_async_to_all_nodes(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    ASSERT_MSG(acc && acc->err == 0, acc ? acc->errstr : "OOM");
+    ASSERT_MSG(acc && valkeyClusterAsyncGetError(acc) == 0, acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
 
     valkeyClusterNodeIterator ni;
     valkeyClusterInitNodeIterator(&ni, &acc->cc);
@@ -437,7 +437,7 @@ void test_async_to_all_nodes(void) {
 
         status = valkeyClusterAsyncCommandToNode(acc, node, commandCallback,
                                                  &r1, "DBSIZE");
-        ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+        ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
     }
 
     // Normal command to trigger disconnect
@@ -464,7 +464,7 @@ void test_async_transaction(void) {
     valkeyClusterOptionsUseLibevent(&options, base);
 
     valkeyClusterAsyncContext *acc = valkeyClusterAsyncConnectWithOptions(&options);
-    ASSERT_MSG(acc && acc->err == 0, acc ? acc->errstr : "OOM");
+    ASSERT_MSG(acc && valkeyClusterAsyncGetError(acc) == 0, acc ? valkeyClusterAsyncGetErrorString(acc) : "OOM");
 
     valkeyClusterNode *node = valkeyClusterGetNodeByKey(&acc->cc, (char *)"foo");
     assert(node);
@@ -473,24 +473,24 @@ void test_async_transaction(void) {
     ExpectedResult r1 = {.type = VALKEY_REPLY_STATUS, .str = "OK"};
     status = valkeyClusterAsyncCommandToNode(acc, node, commandCallback, &r1,
                                              "MULTI");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     ExpectedResult r2 = {.type = VALKEY_REPLY_STATUS, .str = "QUEUED"};
     status = valkeyClusterAsyncCommandToNode(acc, node, commandCallback, &r2,
                                              "SET foo 99");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     ExpectedResult r3 = {.type = VALKEY_REPLY_STATUS, .str = "QUEUED"};
     status = valkeyClusterAsyncCommandToNode(acc, node, commandCallback, &r3,
                                              "INCR foo");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     /* The EXEC command will return an array with result from 2 queued commands. */
     ExpectedResult r4 = {
         .type = VALKEY_REPLY_ARRAY, .elements = 2, .disconnect = true};
     status = valkeyClusterAsyncCommandToNode(acc, node, commandCallback, &r4,
                                              "EXEC ");
-    ASSERT_MSG(status == VALKEY_OK, acc->errstr);
+    ASSERT_MSG(status == VALKEY_OK, valkeyClusterAsyncGetErrorString(acc));
 
     event_base_dispatch(base);
 
@@ -504,7 +504,7 @@ int main(void) {
     options.max_retry = 1;
 
     valkeyClusterContext *cc = valkeyClusterConnectWithOptions(&options);
-    ASSERT_MSG(cc && cc->err == 0, cc ? cc->errstr : "OOM");
+    ASSERT_MSG(cc && valkeyClusterGetError(cc) == 0, cc ? valkeyClusterGetErrorString(cc) : "OOM");
     load_valkey_version(cc);
 
     // Synchronous API

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -22,7 +22,7 @@ void load_valkey_version(valkeyClusterContext *cc) {
         goto abort;
 
     reply = valkeyClusterCommandToNode(cc, node, "INFO");
-    if (reply == NULL || cc->err || reply->type != VALKEY_REPLY_STRING)
+    if (reply == NULL || valkeyClusterGetError(cc) || reply->type != VALKEY_REPLY_STRING)
         goto abort;
     if ((s = strstr(reply->str, VALKEY_VERSION_FIELD)) != NULL)
         s += strlen(VALKEY_VERSION_FIELD);

--- a/tests/ut_slotmap_update.c
+++ b/tests/ut_slotmap_update.c
@@ -466,7 +466,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     nodes = parse_cluster_nodes(cc, c, reply);
     freeReplyObject(reply);
     assert(nodes == NULL);
-    assert(cc->err == VALKEY_ERR_OTHER);
+    assert(valkeyClusterGetError(cc) == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
 
     /* Missing port. */
@@ -475,7 +475,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     nodes = parse_cluster_nodes(cc, c, reply);
     freeReplyObject(reply);
     assert(nodes == NULL);
-    assert(cc->err == VALKEY_ERR_OTHER);
+    assert(valkeyClusterGetError(cc) == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
 
     /* Missing port and cport. */
@@ -484,7 +484,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     nodes = parse_cluster_nodes(cc, c, reply);
     freeReplyObject(reply);
     assert(nodes == NULL);
-    assert(cc->err == VALKEY_ERR_OTHER);
+    assert(valkeyClusterGetError(cc) == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
 
     /* Invalid port. */
@@ -493,7 +493,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     nodes = parse_cluster_nodes(cc, c, reply);
     freeReplyObject(reply);
     assert(nodes == NULL);
-    assert(cc->err == VALKEY_ERR_OTHER);
+    assert(valkeyClusterGetError(cc) == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
 
     valkeyFree(c);


### PR DESCRIPTION
Add accessor functions to get the error status and string from contexts.
These functions replaces any direct access to `err` and `errstr`, and is a preparation for making contexts opaque.

Proposed naming:
```c
/* Blocking API context */
int valkeyGetError(const valkeyContext *c);
const char *valkeyGetErrorString(const valkeyContext *c);

/* Async API context */
int valkeyAsyncGetError(const valkeyAsyncContext *ac);
const char *valkeyAsyncGetErrorString(const valkeyAsyncContext *ac);

/* Blocking Cluster API context */
int valkeyClusterGetError(const valkeyClusterContext *cc);
const char *valkeyClusterGetErrorString(const valkeyClusterContext *cc);

/* Async Cluster API context */
int valkeyClusterAsyncGetError(const valkeyClusterAsyncContext *acc);
const char *valkeyClusterAsyncGetErrorString(const valkeyClusterAsyncContext *acc);
```

Examples and tests have been updated, but READMEs needs to be updated too.
