### PR TITLE
Fix the failing Windows CI job and add caching of vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,17 +237,17 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
-      - run: rm 'C:/Program Files/OpenSSL/' -rf
-        name: remove old openssl
+      - name: Remove installed OpenSSL 1.1.1 (has reached End of Life)
         shell: bash
+        run: rm -rf 'C:/Program Files/OpenSSL/'
       - name: Install dependencies
         run: |
-          choco install -y memurai-developer openssl
+          choco install -y memurai-developer
           # Workaround for libevent that specify minimum CMake version 3.1 (incompatible with CMake >= 4.0).
           sed -i '2i if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")' ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
           sed -i '3i   set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)'  ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
           sed -i '4i endif()'                                       ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
-          vcpkg install --triplet x64-windows pkgconf libevent
+          vcpkg install --triplet x64-windows-release pkgconf libevent openssl
       - name: Build and install
         run: |
           mkdir build && cd build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,18 +240,19 @@ jobs:
       - name: Remove installed OpenSSL 1.1.1 (has reached End of Life)
         shell: bash
         run: rm -rf 'C:/Program Files/OpenSSL/'
-      - name: Install dependencies
+      - name: Install dependencies (choco)
         run: |
           choco install -y memurai-developer
-          # Workaround for libevent that specify minimum CMake version 3.1 (incompatible with CMake >= 4.0).
-          sed -i '2i if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.0")' ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
-          sed -i '3i   set(ENV{CMAKE_POLICY_VERSION_MINIMUM} 3.5)'  ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
-          sed -i '4i endif()'                                       ${env:VCPKG_INSTALLATION_ROOT}/scripts/ports.cmake
-          vcpkg install --triplet x64-windows-release pkgconf libevent openssl
+      - name: Install dependencies (vcpkg)
+        uses: johnwason/vcpkg-action@caa1c94fbb94d8b023a0cc93edf10cd3791349a7 # v7.0.1
+        with:
+          pkgs: pkgconf libevent openssl
+          triplet: x64-windows
+          token: ${{ github.token }}
       - name: Build and install
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DENABLE_TLS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:\vcpkg\scripts\buildsystems\vcpkg.cmake
+          cmake .. -G Ninja -DENABLE_TLS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}\vcpkg\scripts\buildsystems\vcpkg.cmake
           ninja -v install
       - name: Run tests
         working-directory: build


### PR DESCRIPTION
- Install OpenSSL in Windows CI using `vcpkg`.
   There is a mismatch in the package index for OpenSSL in `choco` which currently fails our CI builds.
    Lets use `vcpkg` that probably is a more reliable source.

- Cache the built `vcpkg` packages in CI using [vcpkg-action](https://github.com/johnwason/vcpkg-action).    
    Saves about 7 minutes of runtime on the CI job `windows`.

- Remove superfluous workaround.