### PR TITLE
Build examples on macOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
       - name: Build and install using CMake
         run: |
           mkdir build && cd build
-          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TLS=ON
+          cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TLS=ON -DENABLE_EXAMPLES=ON
           sudo ninja -v install
       - name: Build using Makefile
         run: USE_TLS=1 make

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -47,23 +47,26 @@ if(LIBEV)
 endif()
 
 # Examples using libevent
-find_path(LIBEVENT event.h)
-if(LIBEVENT)
+find_path(LIBEVENT event2/event.h)
+find_library(LIBEVENT_LIBRARY event)
+if(LIBEVENT AND LIBEVENT_LIBRARY)
+  include_directories(${LIBEVENT})
+
   add_executable(example-async-libevent async-libevent.c)
-  target_link_libraries(example-async-libevent valkey::valkey event)
+  target_link_libraries(example-async-libevent valkey::valkey ${LIBEVENT_LIBRARY})
 
   add_executable(example-cluster-async cluster-async.c)
-  target_link_libraries(example-cluster-async valkey::valkey event)
+  target_link_libraries(example-cluster-async valkey::valkey ${LIBEVENT_LIBRARY})
 
   add_executable(example-cluster-clientside-caching-async cluster-clientside-caching-async.c)
-  target_link_libraries(example-cluster-clientside-caching-async valkey::valkey event)
+  target_link_libraries(example-cluster-clientside-caching-async valkey::valkey ${LIBEVENT_LIBRARY})
 
   if(ENABLE_TLS)
     add_executable(example-async-libevent-tls async-libevent-tls.c)
-    target_link_libraries(example-async-libevent-tls valkey::valkey valkey::valkey_tls event)
+    target_link_libraries(example-async-libevent-tls valkey::valkey valkey::valkey_tls ${LIBEVENT_LIBRARY})
 
     add_executable(example-cluster-async-tls cluster-async-tls.c)
-    target_link_libraries(example-cluster-async-tls valkey::valkey valkey::valkey_tls event)
+    target_link_libraries(example-cluster-async-tls valkey::valkey valkey::valkey_tls ${LIBEVENT_LIBRARY})
   endif()
 endif()
 
@@ -76,9 +79,11 @@ endif()
 
 # Examples using libuv
 find_path(LIBUV uv.h)
-if(LIBUV)
+find_library(LIBUV_LIBRARY uv)
+if(LIBUV AND LIBUV_LIBRARY)
+  include_directories(${LIBUV})
   add_executable(example-async-libuv async-libuv.c)
-  target_link_libraries(example-async-libuv valkey::valkey uv)
+  target_link_libraries(example-async-libuv valkey::valkey ${LIBUV_LIBRARY})
 endif()
 
 # Examples using libsystemd

--- a/examples/cluster-clientside-caching-async.c
+++ b/examples/cluster-clientside-caching-async.c
@@ -26,6 +26,7 @@ void modifyKey(const char *key, const char *value);
  * and sets the push callback in the libvalkey context. */
 void connectCallback(valkeyAsyncContext *ac, int status) {
     assert(status == VALKEY_OK);
+    (void)status; /* Suppress unused warning when NDEBUG is defined. */
     valkeyAsyncSetPushCallback(ac, pushCallback);
     valkeyAsyncCommand(ac, NULL, NULL, "HELLO 3");
     valkeyAsyncCommand(ac, NULL, NULL, "CLIENT TRACKING ON");
@@ -48,6 +49,7 @@ void eventCallback(const valkeyClusterContext *cc, int event, void *privdata) {
         int status =
             valkeyClusterAsyncCommand(acc, setCallback, NULL, "SET %s 1", KEY);
         assert(status == VALKEY_OK);
+        (void)status; /* Suppress unused warning when NDEBUG is defined. */
     }
 }
 
@@ -62,6 +64,7 @@ void setCallback(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     int status =
         valkeyClusterAsyncCommand(acc, getCallback1, NULL, "GET %s", KEY);
     assert(status == VALKEY_OK);
+    (void)status; /* Suppress unused warning when NDEBUG is defined. */
 }
 
 /* Message callback for the first 'GET' command. Modifies the key to
@@ -82,6 +85,7 @@ void getCallback1(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
     int status =
         valkeyClusterAsyncCommand(acc, getCallback2, NULL, "GET %s", KEY);
     assert(status == VALKEY_OK);
+    (void)status; /* Suppress unused warning when NDEBUG is defined. */
 }
 
 /* Push message callback handling invalidation messages. */
@@ -121,6 +125,7 @@ void getCallback2(valkeyClusterAsyncContext *acc, void *r, void *privdata) {
 /* A disconnect callback should invalidate all cached keys. */
 void disconnectCallback(const valkeyAsyncContext *ac, int status) {
     assert(status == VALKEY_OK);
+    (void)status; /* Suppress unused warning when NDEBUG is defined. */
     printf("Disconnected from %s:%d\n", ac->c.tcp.host, ac->c.tcp.port);
 
     printf("Invalidate all\n");


### PR DESCRIPTION
Use correct include and library paths when event libraries are installed using homebrew.
Fix warnings in examples when built using `CMAKE_BUILD_TYPE=Release`.