### PR TITLE
Add CI job to build on Solaris

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,17 @@ jobs:
             gmake
             mkdir build && cd build && cmake .. && gmake
 
+  solaris:
+    runs-on: ubuntu-latest
+    name:  Solaris
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Build on Solaris
+        uses: vmactions/solaris-vm@58cbd70c6e051860f9b8f65908cc582938fbbdba # v1.1.5
+        with:
+          prepare: pkgutil -y -i gmake gcc5core openssl_utils
+          run: USE_TLS=1 gmake
+
   build-cross:
     name: Cross-compile ${{ matrix.config.target }}
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ endif
 
 ifeq ($(uname_S),FreeBSD)
   LDFLAGS += -lm
-else ifeq ($(UNAME_S),SunOS)
+else ifeq ($(uname_S),SunOS)
   ifeq ($(shell $(CC) -V 2>&1 | grep -iq 'sun\|studio' && echo true),true)
     SUN_SHARED_FLAG = -G
   else

--- a/src/command.c
+++ b/src/command.c
@@ -28,6 +28,8 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include "fmacros.h"
+
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/src/fmacros.h
+++ b/src/fmacros.h
@@ -1,7 +1,7 @@
 #ifndef VALKEY_FMACRO_H
 #define VALKEY_FMACRO_H
 
-#ifndef _AIX
+#if !defined(_AIX) && !defined(__FreeBSD__)
 #define _XOPEN_SOURCE 600
 #define _POSIX_C_SOURCE 200112L
 #endif


### PR DESCRIPTION
Adds a CI job and some fixes to build on Solaris.

The file `command.c` needs to include `fmacros.h` to enable `strncasecmp` on Solaris (using `_XOPEN_SOURCE`),
but since `command.c` also uses `alloca` we need to make sure it's available on FreeBSD.
Since `alloca` is not visible when using `_POSIX_C_SOURCE` or `_XOPEN_SOURCE` on FreeBSD (they unsets `__BSD_VISIBLE`) we have to remove these defines on FreeBSD.
