### PR TITLE
Update the used `clang-format` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
     - name: Run clang-format style check (.c and .h)
-      uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8 # v4.15.0
+      uses: jidicula/clang-format-action@6cd220de46c89139a0365edae93eee8eb30ca8fe # v4.16.0
       with:
         clang-format-version: '18'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Adhere to the existing coding style and make sure to mimic best possible.
 ### Code formatting
 
 When making a change, please use `git clang-format` or [format-files.sh](./scripts/format-files.sh) to format your changes properly.
-This repository is currently using `clang-format` 18.1.3 to format the code, which can be installed using `pip install clang-format==18.1.3` or other preferred method.
+This repository is currently using `clang-format` 18.1.8 to format the code, which can be installed using `pip install clang-format==18.1.8` or other preferred method.
 
 ## Running cluster tests
 

--- a/scripts/format-files.sh
+++ b/scripts/format-files.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-find examples include libvalkey src tests \
+find examples include src tests \
     \( -name '*.c' -or -name '*.cpp' -or -name '*.h' \) \
     -exec clang-format -i {} + ;

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -29,10 +29,10 @@
     }
 
 #define CHECK_REPLY_OK(_ctx, _reply) \
-    { CHECK_REPLY_STATUS(_ctx, _reply, "OK") }
+    {CHECK_REPLY_STATUS(_ctx, _reply, "OK")}
 
 #define CHECK_REPLY_QUEUED(_ctx, _reply) \
-    { CHECK_REPLY_STATUS(_ctx, _reply, "QUEUED") }
+    {CHECK_REPLY_STATUS(_ctx, _reply, "QUEUED")}
 
 #define CHECK_REPLY_INT(_ctx, _reply, _value)                  \
     {                                                          \


### PR DESCRIPTION
Lift `clang-format` to use version `18.1.8`, which is the default provided version in `Ubuntu` (24.04 LTS).

clang-format `18.1.4` includes a formatting correction that affects `tests/test_utils.h`,
which is now updated (see llvm-project/issues/122087).
The same correction exists in newer clang-format versions provided by `brew` on Mac.