### PR TITLE
Support slotmap updates using CLUSTER NODES in RESP3

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -921,7 +921,7 @@ static dict *parse_cluster_nodes(valkeyClusterContext *cc, valkeyContext *c, val
     int add_replicas = cc->flags & VALKEY_FLAG_PARSE_REPLICAS;
     dict *replicas = NULL;
 
-    if (reply->type != VALKEY_REPLY_STRING) {
+    if (reply->type != VALKEY_REPLY_STRING && reply->type != VALKEY_REPLY_VERB) {
         valkeyClusterSetError(cc, VALKEY_ERR_OTHER, "Unexpected reply type");
         goto error;
     }


### PR DESCRIPTION
When the option `VALKEY_OPT_USE_CLUSTER_NODES` is enabled the slot map is updated using the `CLUSTER NODES` command. If a user has enabled RESP3 by sending the `HELLO 3` command the `CLUSTER NODES` response is a verbatim string instead of a bulk string.
Update so we handle this reply type as well.