### PR TITLE
Optimize read buffer compaction and reduce copying

### DIFF
--- a/include/valkey/read.h
+++ b/include/valkey/read.h
@@ -117,6 +117,8 @@ typedef struct valkeyReader {
 LIBVALKEY_API valkeyReader *valkeyReaderCreateWithFunctions(valkeyReplyObjectFunctions *fn);
 LIBVALKEY_API void valkeyReaderFree(valkeyReader *r);
 LIBVALKEY_API int valkeyReaderFeed(valkeyReader *r, const char *buf, size_t len);
+LIBVALKEY_API int valkeyReaderGetReadBuf(valkeyReader *r, char **buf, size_t *cap, size_t minbytes);
+LIBVALKEY_API void valkeyReaderCommitRead(valkeyReader *r, size_t nread);
 LIBVALKEY_API int valkeyReaderGetReply(valkeyReader *r, void **reply);
 
 #define valkeyReaderSetPrivdata(_r, _p) (int)(((valkeyReader *)(_r))->privdata = (_p))

--- a/src/read.c
+++ b/src/read.c
@@ -790,6 +790,57 @@ oom:
     return VALKEY_ERR;
 }
 
+/* Prepare the reader's internal buffer for a direct read. This compacts
+ * consumed data, ensures at least 'minbytes' of writable space, and returns
+ * a pointer and available capacity. The caller can then read() directly into
+ * *buf and call valkeyReaderCommitRead() with the number of bytes read.
+ * Returns VALKEY_OK on success, VALKEY_ERR on allocation failure. */
+int valkeyReaderGetReadBuf(valkeyReader *r, char **buf, size_t *cap, size_t minbytes) {
+    if (r->err)
+        return VALKEY_ERR;
+
+    /* Destroy internal buffer when it is empty and is quite large. */
+    if (r->len == 0 && r->maxbuf != 0 && sdsavail(r->buf) > r->maxbuf) {
+        sdsfree(r->buf);
+        r->buf = sdsempty();
+        if (r->buf == NULL)
+            goto oom;
+        r->pos = 0;
+    }
+
+    /* Compact consumed data. */
+    if (r->pos > 0) {
+        if (sdslen(r->buf) > SSIZE_MAX)
+            goto oom;
+        sdsrange(r->buf, r->pos, -1);
+        r->pos = 0;
+        r->len = sdslen(r->buf);
+    }
+
+    /* Ensure enough writable space. */
+    if (sdsavail(r->buf) < minbytes) {
+        sds newbuf = sdsMakeRoomFor(r->buf, minbytes);
+        if (newbuf == NULL)
+            goto oom;
+        r->buf = newbuf;
+    }
+
+    *buf = r->buf + sdslen(r->buf);
+    *cap = sdsavail(r->buf);
+    return VALKEY_OK;
+
+oom:
+    valkeyReaderSetErrorOOM(r);
+    return VALKEY_ERR;
+}
+
+/* Commit bytes that were written directly into the buffer obtained from
+ * valkeyReaderGetReadBuf(). */
+void valkeyReaderCommitRead(valkeyReader *r, size_t nread) {
+    sdsIncrLen(r->buf, (int)nread);
+    r->len = sdslen(r->buf);
+}
+
 int valkeyReaderGetReply(valkeyReader *r, void **reply) {
     /* Default target pointer to NULL. */
     if (reply != NULL)

--- a/src/read.c
+++ b/src/read.c
@@ -747,47 +747,20 @@ void valkeyReaderFree(valkeyReader *r) {
 }
 
 int valkeyReaderFeed(valkeyReader *r, const char *buf, size_t len) {
-    sds newbuf;
-
     /* Return early when this reader is in an erroneous state. */
     if (r->err)
         return VALKEY_ERR;
 
-    /* Copy the provided buffer. */
     if (buf != NULL && len >= 1) {
-        /* Destroy internal buffer when it is empty and is quite large. */
-        if (r->len == 0 && r->maxbuf != 0 && sdsavail(r->buf) > r->maxbuf) {
-            sdsfree(r->buf);
-            r->buf = sdsempty();
-            if (r->buf == 0)
-                goto oom;
-
-            r->pos = 0;
-        }
-
-        /* Discard consumed data before appending, to avoid unbounded growth.
-         * This replaces the per-reply sdsrange() in valkeyReaderGetReply(),
-         * so the memmove happens at most once per feed call. */
-        if (r->pos > 0) {
-            if (sdslen(r->buf) > SSIZE_MAX)
-                goto oom;
-            sdsrange(r->buf, r->pos, -1);
-            r->pos = 0;
-            r->len = sdslen(r->buf);
-        }
-
-        newbuf = sdscatlen(r->buf, buf, len);
-        if (newbuf == NULL)
-            goto oom;
-
-        r->buf = newbuf;
-        r->len = sdslen(r->buf);
+        char *dest;
+        size_t cap;
+        if (valkeyReaderGetReadBuf(r, &dest, &cap, len) != VALKEY_OK)
+            return VALKEY_ERR;
+        memcpy(dest, buf, len);
+        valkeyReaderCommitRead(r, len);
     }
 
     return VALKEY_OK;
-oom:
-    valkeyReaderSetErrorOOM(r);
-    return VALKEY_ERR;
 }
 
 /* Prepare the reader's internal buffer for a direct read. This compacts
@@ -798,6 +771,12 @@ oom:
 int valkeyReaderGetReadBuf(valkeyReader *r, char **buf, size_t *cap, size_t minbytes) {
     if (r->err)
         return VALKEY_ERR;
+
+    if (minbytes > SSIZE_MAX) {
+        valkeyReaderSetError(r, VALKEY_ERR_PROTOCOL,
+                             "Requested buffer size too large");
+        return VALKEY_ERR;
+    }
 
     /* Destroy internal buffer when it is empty and is quite large. */
     if (r->len == 0 && r->maxbuf != 0 && sdsavail(r->buf) > r->maxbuf) {
@@ -810,8 +789,11 @@ int valkeyReaderGetReadBuf(valkeyReader *r, char **buf, size_t *cap, size_t minb
 
     /* Compact consumed data. */
     if (r->pos > 0) {
-        if (sdslen(r->buf) > SSIZE_MAX)
-            goto oom;
+        if (sdslen(r->buf) > SSIZE_MAX) {
+            valkeyReaderSetError(r, VALKEY_ERR_PROTOCOL,
+                                 "Reader buffer is too large");
+            return VALKEY_ERR;
+        }
         sdsrange(r->buf, r->pos, -1);
         r->pos = 0;
         r->len = sdslen(r->buf);
@@ -827,6 +809,8 @@ int valkeyReaderGetReadBuf(valkeyReader *r, char **buf, size_t *cap, size_t minb
 
     *buf = r->buf + sdslen(r->buf);
     *cap = sdsavail(r->buf);
+    if (*cap > SSIZE_MAX)
+        *cap = SSIZE_MAX;
     return VALKEY_OK;
 
 oom:
@@ -837,7 +821,8 @@ oom:
 /* Commit bytes that were written directly into the buffer obtained from
  * valkeyReaderGetReadBuf(). */
 void valkeyReaderCommitRead(valkeyReader *r, size_t nread) {
-    sdsIncrLen(r->buf, (int)nread);
+    assert(nread <= SSIZE_MAX);
+    sdsIncrLen(r->buf, (ssize_t)nread);
     r->len = sdslen(r->buf);
 }
 

--- a/src/read.c
+++ b/src/read.c
@@ -765,6 +765,17 @@ int valkeyReaderFeed(valkeyReader *r, const char *buf, size_t len) {
             r->pos = 0;
         }
 
+        /* Discard consumed data before appending, to avoid unbounded growth.
+         * This replaces the per-reply sdsrange() in valkeyReaderGetReply(),
+         * so the memmove happens at most once per feed call. */
+        if (r->pos > 0) {
+            if (sdslen(r->buf) > SSIZE_MAX)
+                goto oom;
+            sdsrange(r->buf, r->pos, -1);
+            r->pos = 0;
+            r->len = sdslen(r->buf);
+        }
+
         newbuf = sdscatlen(r->buf, buf, len);
         if (newbuf == NULL)
             goto oom;
@@ -811,17 +822,6 @@ int valkeyReaderGetReply(valkeyReader *r, void **reply) {
     /* Return ASAP when an error occurred. */
     if (r->err)
         return VALKEY_ERR;
-
-    /* Discard part of the buffer when we've consumed at least 1k, to avoid
-     * doing unnecessary calls to memmove() in sds.c. */
-    if (r->pos >= 1024) {
-        /* No length check in Valkeys sdsrange() */
-        if (sdslen(r->buf) > SSIZE_MAX)
-            return VALKEY_ERR;
-        sdsrange(r->buf, r->pos, -1);
-        r->pos = 0;
-        r->len = sdslen(r->buf);
-    }
 
     /* Emit a reply when there is one. */
     if (r->ridx == -1) {

--- a/src/sds.c
+++ b/src/sds.c
@@ -329,7 +329,7 @@ void *sdsAllocPtr(sds s) {
  * ... check for nread <= 0 and handle it ...
  * sdsIncrLen(s, nread);
  */
-void sdsIncrLen(sds s, int incr) {
+void sdsIncrLen(sds s, ssize_t incr) {
     unsigned char flags = s[-1];
     size_t len;
     switch (flags & SDS_TYPE_MASK) {

--- a/src/sds.h
+++ b/src/sds.h
@@ -261,7 +261,7 @@ sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Low level functions exposed to the user API */
 sds sdsMakeRoomFor(sds s, size_t addlen);
-void sdsIncrLen(sds s, int incr);
+void sdsIncrLen(sds s, ssize_t incr);
 sds sdsRemoveFreeSpace(sds s);
 size_t sdsAllocSize(sds s);
 void *sdsAllocPtr(sds s);

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -1002,7 +1002,7 @@ valkeyPushFn *valkeySetPushCallback(valkeyContext *c, valkeyPushFn *fn) {
  * After this function is called, you may use valkeyGetReplyFromReader to
  * see if there is a reply available. */
 int valkeyBufferRead(valkeyContext *c) {
-    int nread;
+    ssize_t nread;
 
     /* Return early when the context has seen an error. */
     if (c->err)

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -1002,7 +1002,6 @@ valkeyPushFn *valkeySetPushCallback(valkeyContext *c, valkeyPushFn *fn) {
  * After this function is called, you may use valkeyGetReplyFromReader to
  * see if there is a reply available. */
 int valkeyBufferRead(valkeyContext *c) {
-    char buf[1024 * 16];
     int nread;
 
     /* Return early when the context has seen an error. */
@@ -1021,13 +1020,20 @@ int valkeyBufferRead(valkeyContext *c) {
         }
         return c->funcs->read_zc_done(c);
     }
-    nread = c->funcs->read(c, buf, sizeof(buf));
+
+    /* Read directly into the reader's buffer to avoid a memcpy. */
+    char *buf;
+    size_t cap;
+    if (valkeyReaderGetReadBuf(c->reader, &buf, &cap, 1024 * 16) != VALKEY_OK) {
+        valkeySetError(c, c->reader->err, c->reader->errstr);
+        return VALKEY_ERR;
+    }
+    nread = c->funcs->read(c, buf, cap);
     if (nread < 0) {
         return VALKEY_ERR;
     }
-    if (nread > 0 && valkeyReaderFeed(c->reader, buf, nread) != VALKEY_OK) {
-        valkeySetError(c, c->reader->err, c->reader->errstr);
-        return VALKEY_ERR;
+    if (nread > 0) {
+        valkeyReaderCommitRead(c->reader, nread);
     }
     return VALKEY_OK;
 }

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -11,18 +11,9 @@
  * Tests will call a libvalkeycluster API-function while iterating on a number,
  * the number of successful allocations during the call before it hits an OOM.
  * The result and the error code is then checked to show "Out of memory".
- * As a last step the correct number of allocations is prepared to get a
- * successful API-function call.
- *
- * Tip:
- * When this testcase fails after code changes in the library, run the testcase
- * in `gdb` to find which API call that failed, and in which iteration.
- * - Go to the correct stack frame to find which API that triggered a failure.
- * - Use the gdb command `print i` to find which iteration.
- * - Investigate if a failure or a success is expected after the code change.
- * - Set correct `i` in for-loop and the `prepare_allocation_test()` for the test.
- *   Correct `i` can be hard to know, finding the correct number might require trial
- *   and error of running with increased/decreased `i` until the edge is found.
+ * The required number of allocations for a successful call is discovered at
+ * runtime rather than hardcoded, making the tests resilient to changes in
+ * internal allocation patterns.
  */
 #define _XOPEN_SOURCE 600 /* For strdup() */
 #include "adapters/libevent.h"
@@ -148,15 +139,16 @@ void test_alloc_failure_handling(void) {
         valkeyReply *reply;
         const char *cmd = "SET key value";
 
-        for (int i = 0; i < 33; ++i) {
-            prepare_allocation_test(cc, i);
+        /* Discover the number of allocations required for a successful call. */
+        int n;
+        for (n = 0; n < 1000; n++) {
+            prepare_allocation_test(cc, n);
             reply = (valkeyReply *)valkeyClusterCommand(cc, cmd);
-            assert(reply == NULL);
+            if (reply != NULL)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
         }
-
-        prepare_allocation_test(cc, 33);
-        reply = (valkeyReply *)valkeyClusterCommand(cc, cmd);
+        assert(n < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -169,17 +161,15 @@ void test_alloc_failure_handling(void) {
         valkeyClusterNode *node = valkeyClusterGetNodeByKey(cc, (char *)"key");
         assert(node);
 
-        // OOM failing commands
-        for (int i = 0; i < 32; ++i) {
-            prepare_allocation_test(cc, i);
+        int n;
+        for (n = 0; n < 1000; n++) {
+            prepare_allocation_test(cc, n);
             reply = valkeyClusterCommandToNode(cc, node, cmd);
-            assert(reply == NULL);
+            if (reply != NULL)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
         }
-
-        // Successful command
-        prepare_allocation_test(cc, 32);
-        reply = valkeyClusterCommandToNode(cc, node, cmd);
+        assert(n < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -189,37 +179,35 @@ void test_alloc_failure_handling(void) {
         valkeyReply *reply;
         const char *cmd = "SET foo one";
 
-        for (int i = 0; i < 33; ++i) {
-            prepare_allocation_test(cc, i);
+        /* Discover allocations needed for a successful append. */
+        int na;
+        for (na = 0; na < 1000; na++) {
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommand(cc, cmd);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
+        assert(na < 1000);
 
-        for (int i = 0; i < 4; ++i) {
-            // Appended command lost when receiving error from valkey
-            // during a GetReply, needs a new append for each test loop
-            prepare_allocation_test(cc, 33);
+        /* Discover allocations needed for a successful GetReply. */
+        int ng;
+        for (ng = 0; ng < 1000; ng++) {
+            /* Appended command lost when receiving error during a GetReply,
+             * needs a new append for each test loop. */
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommand(cc, cmd);
             assert(result == VALKEY_OK);
 
-            prepare_allocation_test(cc, i);
+            prepare_allocation_test(cc, ng);
             result = valkeyClusterGetReply(cc, (void *)&reply);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
-
-        prepare_allocation_test(cc, 34);
-        result = valkeyClusterAppendCommand(cc, cmd);
-        assert(result == VALKEY_OK);
-
-        prepare_allocation_test(cc, 4);
-        result = valkeyClusterGetReply(cc, (void *)&reply);
-        assert(result == VALKEY_OK);
+        assert(ng < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -232,39 +220,33 @@ void test_alloc_failure_handling(void) {
         valkeyClusterNode *node = valkeyClusterGetNodeByKey(cc, (char *)"foo");
         assert(node);
 
-        // OOM failing appends
-        for (int i = 0; i < 34; ++i) {
-            prepare_allocation_test(cc, i);
+        /* Discover allocations needed for a successful append to node. */
+        int na;
+        for (na = 0; na < 1000; na++) {
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommandToNode(cc, node, cmd);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
+        assert(na < 1000);
 
-        // OOM failing GetResults
-        for (int i = 0; i < 4; ++i) {
-            // First a successful append
-            prepare_allocation_test(cc, 34);
+        /* Discover allocations needed for a successful GetReply. */
+        int ng;
+        for (ng = 0; ng < 1000; ng++) {
+            prepare_allocation_test(cc, na);
             result = valkeyClusterAppendCommandToNode(cc, node, cmd);
             assert(result == VALKEY_OK);
 
-            prepare_allocation_test(cc, i);
+            prepare_allocation_test(cc, ng);
             result = valkeyClusterGetReply(cc, (void *)&reply);
-            assert(result == VALKEY_ERR);
+            if (result == VALKEY_OK)
+                break;
             ASSERT_STR_EQ(cc->errstr, "Out of memory");
-
             valkeyClusterReset(cc);
         }
-
-        // Successful append and GetReply
-        prepare_allocation_test(cc, 35);
-        result = valkeyClusterAppendCommandToNode(cc, node, cmd);
-        assert(result == VALKEY_OK);
-
-        prepare_allocation_test(cc, 4);
-        result = valkeyClusterGetReply(cc, (void *)&reply);
-        assert(result == VALKEY_OK);
+        assert(ng < 1000);
         CHECK_REPLY_OK(cc, reply);
         freeReplyObject(reply);
     }
@@ -318,18 +300,19 @@ void test_alloc_failure_handling(void) {
         freeReplyObject(reply);
 
         /* Test ASK reply handling with OOM */
-        for (int i = 0; i < 45; ++i) {
-            prepare_allocation_test(cc, i);
-            reply = valkeyClusterCommand(cc, "GET foo");
-            assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        {
+            int n;
+            for (n = 0; n < 1000; n++) {
+                prepare_allocation_test(cc, n);
+                reply = valkeyClusterCommand(cc, "GET foo");
+                if (reply != NULL)
+                    break;
+                ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            }
+            assert(n < 1000);
+            CHECK_REPLY_STR(cc, reply, "one");
+            freeReplyObject(reply);
         }
-
-        /* Test ASK reply handling without OOM */
-        prepare_allocation_test(cc, 45);
-        reply = valkeyClusterCommand(cc, "GET foo");
-        CHECK_REPLY_STR(cc, reply, "one");
-        freeReplyObject(reply);
 
         /* Finalize the migration. Skip OOM testing during these steps by
          * allowing a high number of allocations. */
@@ -347,18 +330,19 @@ void test_alloc_failure_handling(void) {
         freeReplyObject(reply);
 
         /* Test MOVED reply handling with OOM */
-        for (int i = 0; i < 32; ++i) {
-            prepare_allocation_test(cc, i);
-            reply = valkeyClusterCommand(cc, "GET foo");
-            assert(reply == NULL);
-            ASSERT_STR_EQ(cc->errstr, "Out of memory");
+        {
+            int n;
+            for (n = 0; n < 1000; n++) {
+                prepare_allocation_test(cc, n);
+                reply = valkeyClusterCommand(cc, "GET foo");
+                if (reply != NULL)
+                    break;
+                ASSERT_STR_EQ(cc->errstr, "Out of memory");
+            }
+            assert(n < 1000);
+            CHECK_REPLY_STR(cc, reply, "one");
+            freeReplyObject(reply);
         }
-
-        /* Test MOVED reply handling without OOM */
-        prepare_allocation_test(cc, 32);
-        reply = valkeyClusterCommand(cc, "GET foo");
-        CHECK_REPLY_STR(cc, reply, "one");
-        freeReplyObject(reply);
 
         /* MOVED triggers a slotmap update which currently replaces all cluster_node
          * objects. We can get the new objects by searching for its server ports.


### PR DESCRIPTION
Do compaction of the read buffer (memmove) before feeding more data to the reader, instead of after each parsed command.

Previously, sdsrange() was called in valkeyReaderGetReply() to compact the read buffer after consuming >= 1024 bytes. With pipelining, GetReply is called many times per Feed call (once per reply), causing repeated memmove() operations on the remaining buffer data.

Move the compaction to valkeyReaderFeed(), right before appending new data. This ensures the memmove happens at most once per network read instead of once per parsed reply.

Additionally, make space in the allocated read buffer before the read() call and read directly into the allocated reply buffer instead of copying it via a static buffer. A public API for this is added (valkeyReaderGetReadBuf + valkeyReaderCommitRead).

Profiling
---------

Profiled using valkey-benchmark on macOS (Apple M4 Pro) with:

    valkey-benchmark -P 32 -d 1024 -r 1000000 -n 3000000 -c 50 -t set,get

Server ran with --io-threads 4 to avoid being server-bottlenecked.

Flamegraph sampling (macOS `sample` tool, 10s at 1ms intervals) of the valkey-benchmark process shows the following top userspace hotspots:

| Read path hotspot | Original | After compaction fix | After direct read |
|---|---|---|---|
| sdsrange → memmove (GetReply) | 250 | 0 ← eliminated | 0 |
| valkeyReaderFeed → sdscatlen → memmove | 38 | 43 | 0 ← eliminated |
| __recvfrom (kernel) | 246 | 266 | 295 |
| createStringObject → memmove | 25 | 27 | 28 |

After the first change, the sdsrange memmove (250 samples) is eliminated and the compaction cost is absorbed into valkeyReaderFeed with negligible overhead increase (38 -> 43 samples). After the second change, the sdscatlen -> memmove is also eliminated.