### PR TITLE
Rename `freeReplyObject` to `valkeyFreeReplyObject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_TLS=1 -DENABLE_RDMA=1 ..
 sudo make install
 ```
 
+### Other build options
+
+`VALKEY_NO_DEPRECATED` — Disable deprecated names (e.g. `freeReplyObject`). Define this to ensure only the new `valkey`-prefixed names are used.
+
 ## Contributing
 
 Please see [`CONTRIBUTING.md`](https://github.com/valkey-io/libvalkey/blob/main/CONTRIBUTING.md).

--- a/docs/cluster.md
+++ b/docs/cluster.md
@@ -100,7 +100,7 @@ if (reply == NULL) {
 } else {
     // Handle reply..
 }
-freeReplyObject(reply);
+valkeyFreeReplyObject(reply);
 ```
 
 Commands will be sent to the cluster node that the client perceives handling the given key.
@@ -160,14 +160,14 @@ if (valkeyClusterGetReply(cc,&reply) != VALKEY_OK) {
     exit(1);
 }
 // Handle the reply for SET here.
-freeReplyObject(reply);
+valkeyFreeReplyObject(reply);
 
 if (valkeyClusterGetReply(cc,&reply) != VALKEY_OK) {
     fprintf(stderr, "Error reading reply %zu: %s\n", i, c->errstr);
     exit(1);
 }
 // Handle the reply for GET here.
-freeReplyObject(reply);
+valkeyFreeReplyObject(reply);
 ```
 
 ### Events

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -18,6 +18,7 @@ The type `sds` is removed from the public API.
 ### Renamed API functions
 
 * `redisAsyncSetConnectCallbackNC` is renamed to `valkeyAsyncSetConnectCallback`.
+* `freeReplyObject` is renamed to `valkeyFreeReplyObject`.
 
 ### Removed API functions
 

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -76,7 +76,7 @@ There are also several flags you can specify when using the `valkeyOptions` help
 | `VALKEY_OPT_REUSEADDR` | Tells libvalkey to set the [SO_REUSEADDR](https://man7.org/linux/man-pages/man7/socket.7.html) socket option |
 | `VALKEY_OPT_PREFER_IPV4`<br>`VALKEY_OPT_PREFER_IPV6`<br>`VALKEY_OPT_PREFER_IP_UNSPEC` | Informs libvalkey to either prefer IPv4 or IPv6 when invoking [getaddrinfo](https://man7.org/linux/man-pages/man3/gai_strerror.3.html).  `VALKEY_OPT_PREFER_IP_UNSPEC` will cause libvalkey to specify `AF_UNSPEC` in the getaddrinfo call, which means both IPv4 and IPv6 addresses will be searched simultaneously.<br>Libvalkey prefers IPv4 by default. |
 | `VALKEY_OPT_NO_PUSH_AUTOFREE` | Tells libvalkey to not install the default RESP3 PUSH handler (which just intercepts and frees the replies).  This is useful in situations where you want to process these messages in-band. |
-| `VALKEY_OPT_NOAUTOFREEREPLIES` | **ASYNC**: tells libvalkey not to automatically invoke `freeReplyObject` after executing the reply callback. |
+| `VALKEY_OPT_NOAUTOFREEREPLIES` | **ASYNC**: tells libvalkey not to automatically invoke `valkeyFreeReplyObject` after executing the reply callback. |
 | `VALKEY_OPT_NOAUTOFREE` | **ASYNC**: Tells libvalkey not to automatically free the `valkeyAsyncContext` on connection/communication failure, but only if the user makes an explicit call to `valkeyAsyncDisconnect` or `valkeyAsyncFree` |
 | `VALKEY_OPT_MPTCP` | Tells libvalkey to use multipath TCP (MPTCP). Note that only when both the server and client are using MPTCP do they establish an MPTCP connection between them; otherwise, they use a regular TCP connection instead. |
 
@@ -97,7 +97,7 @@ if (reply == NULL) {
 }
 
 printf("New value of 'counter' is %lld\n", reply->integer);
-freeReplyObject(reply);
+valkeyFreeReplyObject(reply);
 ```
 
 If you need to deliver binary safe strings to the server, you can use the `%b` format specifier which requires you to pass the length as well.
@@ -144,12 +144,12 @@ When a `valkeyReply` is returned, you should test the `valkeyReply->type` field 
 
 ### Disconnecting/cleanup
 
-When libvalkey returns non-null `valkeyReply` struts you are responsible for freeing them with `freeReplyObject`.  In order to disconnect and free the context simply call `valkeyFree`.
+When libvalkey returns non-null `valkeyReply` struts you are responsible for freeing them with `valkeyFreeReplyObject`.  In order to disconnect and free the context simply call `valkeyFree`.
 
 ```c
 valkeyReply *reply = valkeyCommand(ctx, "set %s %s", "foo", "bar");
 // Error handling ...
-freeReplyObject(reply);
+valkeyFreeReplyObject(reply);
 
 // Disconnect and free context
 valkeyFree(ctx);
@@ -181,7 +181,7 @@ for (size_t i = 0; i < 100000; i++) {
     }
 
     printf("INCRBY key:%zu => %lld\n", i, reply->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 ```
 
@@ -193,7 +193,7 @@ assert(reply != NULL && !c->err);
 
 while (valkeyGetReply(c, (void**)&reply) == VALKEY_OK) {
     // Do something with the message...
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 ```
 

--- a/examples/blocking-push.c
+++ b/examples/blocking-push.c
@@ -54,7 +54,7 @@ static void assertReplyAndFree(valkeyContext *context, valkeyReply *reply, int t
         panicAbort("Expected reply type %d but got type %d", type, reply->type);
     }
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 /* Switch to the RESP3 protocol and enable client tracking */
@@ -71,7 +71,7 @@ static void enableClientTracking(valkeyContext *c) {
         exit(-1);
     }
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Enable client tracking */
     reply = valkeyCommand(c, "CLIENT TRACKING ON");
@@ -95,7 +95,7 @@ void pushReplyHandler(void *privdata, void *r) {
     printf("pushReplyHandler(): INVALIDATE '%s' (invalidation count: %d)\n",
            reply->element[1]->element[0]->str, *invalidations);
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 /* We aren't actually freeing anything here, but it is included to show that we can

--- a/examples/blocking-tls.c
+++ b/examples/blocking-tls.c
@@ -58,40 +58,40 @@ int main(int argc, char **argv) {
     /* PING server */
     reply = valkeyCommand(c, "PING");
     printf("PING: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Set a key */
     reply = valkeyCommand(c, "SET %s %s", "foo", "hello world");
     printf("SET: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Set a key using binary safe API */
     reply = valkeyCommand(c, "SET %b %b", "bar", (size_t)3, "hello", (size_t)5);
     printf("SET (binary API): %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Try a GET and two INCR */
     reply = valkeyCommand(c, "GET foo");
     printf("GET foo: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyCommand(c, "INCR counter");
     printf("INCR counter: %lld\n", reply->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     /* again ... */
     reply = valkeyCommand(c, "INCR counter");
     printf("INCR counter: %lld\n", reply->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Create a list of numbers, from 0 to 9 */
     reply = valkeyCommand(c, "DEL mylist");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     for (j = 0; j < 10; j++) {
         char buf[64];
 
         snprintf(buf, 64, "%u", j);
         reply = valkeyCommand(c, "LPUSH mylist element-%s", buf);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 
     /* Let's check what we have inside the list */
@@ -101,7 +101,7 @@ int main(int argc, char **argv) {
             printf("%u) %s\n", j, reply->element[j]->str);
         }
     }
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Disconnects and frees the context */
     valkeyFree(c);

--- a/examples/blocking.c
+++ b/examples/blocking.c
@@ -47,7 +47,7 @@ static void example_argv_command(valkeyContext *c, size_t n) {
         printf("%s reply: %lld\n", argv[0], reply->integer);
     }
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Clean up */
     for (size_t i = 2; i < (n + 2); i++) {
@@ -93,40 +93,40 @@ int main(int argc, char **argv) {
     /* PING server */
     reply = valkeyCommand(c, "PING");
     printf("PING: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Set a key */
     reply = valkeyCommand(c, "SET %s %s", "foo", "hello world");
     printf("SET: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Set a key using binary safe API */
     reply = valkeyCommand(c, "SET %b %b", "bar", (size_t)3, "hello", (size_t)5);
     printf("SET (binary API): %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Try a GET and two INCR */
     reply = valkeyCommand(c, "GET foo");
     printf("GET foo: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyCommand(c, "INCR counter");
     printf("INCR counter: %lld\n", reply->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     /* again ... */
     reply = valkeyCommand(c, "INCR counter");
     printf("INCR counter: %lld\n", reply->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Create a list of numbers, from 0 to 9 */
     reply = valkeyCommand(c, "DEL mylist");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     for (j = 0; j < 10; j++) {
         char buf[64];
 
         snprintf(buf, 64, "%u", j);
         reply = valkeyCommand(c, "LPUSH mylist element-%s", buf);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 
     /* Let's check what we have inside the list */
@@ -136,7 +136,7 @@ int main(int argc, char **argv) {
             printf("%u) %s\n", j, reply->element[j]->str);
         }
     }
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* See function for an example of valkeyCommandArgv */
     example_argv_command(c, 10);

--- a/examples/cluster-clientside-caching-async.c
+++ b/examples/cluster-clientside-caching-async.c
@@ -139,7 +139,7 @@ void modifyKey(const char *key, const char *value) {
 
     valkeyReply *reply = valkeyClusterCommand(cc, "SET %s %s", key, value);
     assert(reply != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterFree(cc);
 }

--- a/examples/cluster-simple.c
+++ b/examples/cluster-simple.c
@@ -22,11 +22,11 @@ int main(void) {
 
     valkeyReply *reply = valkeyClusterCommand(cc, "SET %s %s", "key", "value");
     printf("SET: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyReply *reply2 = valkeyClusterCommand(cc, "GET %s", "key");
     printf("GET: %s\n", reply2->str);
-    freeReplyObject(reply2);
+    valkeyFreeReplyObject(reply2);
 
     valkeyClusterFree(cc);
     return 0;

--- a/examples/cluster-tls.c
+++ b/examples/cluster-tls.c
@@ -42,7 +42,7 @@ int main(void) {
         exit(-1);
     }
     printf("SET: %s\n", reply->str);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyReply *reply2 = valkeyClusterCommand(cc, "GET %s", "key");
     if (!reply2) {
@@ -50,7 +50,7 @@ int main(void) {
         exit(-1);
     }
     printf("GET: %s\n", reply2->str);
-    freeReplyObject(reply2);
+    valkeyFreeReplyObject(reply2);
 
     valkeyClusterFree(cc);
     valkeyFreeTLSContext(tls);

--- a/include/valkey/valkey.h
+++ b/include/valkey/valkey.h
@@ -142,7 +142,7 @@ typedef struct valkeyReply {
 LIBVALKEY_API valkeyReader *valkeyReaderCreate(void);
 
 /* Function to free the reply objects hivalkey returns by default. */
-LIBVALKEY_API void freeReplyObject(void *reply);
+LIBVALKEY_API void valkeyFreeReplyObject(void *reply);
 
 /* Functions to format a command according to the protocol. */
 LIBVALKEY_API int valkeyvFormatCommand(char **target, const char *format, va_list ap);

--- a/include/valkey/valkey.h
+++ b/include/valkey/valkey.h
@@ -144,6 +144,11 @@ LIBVALKEY_API valkeyReader *valkeyReaderCreate(void);
 /* Function to free the reply objects hivalkey returns by default. */
 LIBVALKEY_API void valkeyFreeReplyObject(void *reply);
 
+/* Deprecated name, provided for backward compatibility. */
+#ifndef VALKEY_NO_DEPRECATED
+#define freeReplyObject valkeyFreeReplyObject
+#endif
+
 /* Functions to format a command according to the protocol. */
 LIBVALKEY_API int valkeyvFormatCommand(char **target, const char *format, va_list ap);
 LIBVALKEY_API int valkeyFormatCommand(char **target, const char *format, ...);

--- a/src/async.c
+++ b/src/async.c
@@ -176,8 +176,8 @@ valkeyAsyncContext *valkeyAsyncConnectWithOptions(const valkeyOptions *options) 
     valkeyContext *c;
     valkeyAsyncContext *ac;
 
-    /* Clear any erroneously set sync callback and flag that we don't want to
-     * use freeReplyObject by default. */
+    /* Clear any erroneously set sync callback, and flag that we don't want to
+     * use valkeyFreeReplyObject by default. */
     myOptions.push_cb = NULL;
     myOptions.options |= VALKEY_OPT_NO_PUSH_AUTOFREE;
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -349,11 +349,11 @@ static int authenticate(valkeyClusterContext *cc, valkeyContext *c) {
         goto error;
     }
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     return VALKEY_OK;
 
 error:
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     return VALKEY_ERR;
 }
@@ -370,10 +370,10 @@ static int select_db(valkeyClusterContext *cc, valkeyContext *c) {
     }
     if (reply->type == VALKEY_REPLY_ERROR) {
         valkeyClusterSetError(cc, VALKEY_ERR_OTHER, reply->str);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         return VALKEY_ERR;
     }
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     return VALKEY_OK;
 }
 
@@ -1033,7 +1033,7 @@ static int clusterUpdateRouteHandleReply(valkeyClusterContext *cc,
     }
     if (reply->type == VALKEY_REPLY_ERROR) {
         valkeyClusterSetError(cc, VALKEY_ERR_OTHER, reply->str);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         return VALKEY_ERR;
     }
 
@@ -1043,7 +1043,7 @@ static int clusterUpdateRouteHandleReply(valkeyClusterContext *cc,
     } else {
         nodes = parse_cluster_slots(cc, c, reply);
     }
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     return updateNodesAndSlotmap(cc, nodes);
 }
 
@@ -1943,7 +1943,7 @@ ask_retry:
         switch (error_type) {
         case CLUSTER_ERR_MOVED:
             node = getNodeFromRedirectReply(cc, c, reply, &slot);
-            freeReplyObject(reply);
+            valkeyFreeReplyObject(reply);
             reply = NULL;
 
             if (node == NULL) {
@@ -1985,7 +1985,7 @@ ask_retry:
                 goto error;
             }
 
-            freeReplyObject(reply);
+            valkeyFreeReplyObject(reply);
             reply = NULL;
 
             c = valkeyClusterGetValkeyContext(cc, node);
@@ -2002,13 +2002,13 @@ ask_retry:
                 goto error;
             }
 
-            freeReplyObject(reply);
+            valkeyFreeReplyObject(reply);
             reply = NULL;
 
             goto ask_retry;
         case CLUSTER_ERR_TRYAGAIN:
         case CLUSTER_ERR_CLUSTERDOWN:
-            freeReplyObject(reply);
+            valkeyFreeReplyObject(reply);
             reply = NULL;
             goto retry;
 
@@ -2022,7 +2022,7 @@ ask_retry:
 
 error:
     if (reply) {
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = NULL;
     }
 
@@ -2035,7 +2035,7 @@ done:
             valkeyClusterClearError(cc);
             if (valkeyClusterUpdateSlotmap(cc) != VALKEY_OK) {
                 /* Clear the reply to indicate failure. */
-                freeReplyObject(reply);
+                valkeyFreeReplyObject(reply);
                 reply = NULL;
             }
         }
@@ -2543,7 +2543,7 @@ void valkeyClusterReset(valkeyClusterContext *cc) {
         do {
             status = valkeyClusterGetReply(cc, &reply);
             if (status == VALKEY_OK) {
-                freeReplyObject(reply);
+                valkeyFreeReplyObject(reply);
             } else {
                 valkeyClusterClearAll(cc);
                 break;

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -64,7 +64,7 @@ static valkeyReplyObjectFunctions defaultFunctions = {
     createDoubleObject,
     createNilObject,
     createBoolObject,
-    freeReplyObject};
+    valkeyFreeReplyObject};
 
 /* Create a reply object */
 static valkeyReply *createReplyObject(int type) {
@@ -78,7 +78,7 @@ static valkeyReply *createReplyObject(int type) {
 }
 
 /* Free a reply object */
-void freeReplyObject(void *reply) {
+void valkeyFreeReplyObject(void *reply) {
     valkeyReply *r = reply;
     size_t j;
 
@@ -97,7 +97,7 @@ void freeReplyObject(void *reply) {
     case VALKEY_REPLY_PUSH:
         if (r->element != NULL) {
             for (j = 0; j < r->elements; j++)
-                freeReplyObject(r->element[j]);
+                valkeyFreeReplyObject(r->element[j]);
             vk_free(r->element);
         }
         break;
@@ -161,7 +161,7 @@ static void *createStringObject(const valkeyReadTask *task, char *str, size_t le
     return r;
 
 oom:
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
     return NULL;
 }
 
@@ -175,7 +175,7 @@ static void *createArrayObject(const valkeyReadTask *task, size_t elements) {
     if (elements > 0) {
         r->element = vk_calloc(elements, sizeof(valkeyReply *));
         if (r->element == NULL) {
-            freeReplyObject(r);
+            valkeyFreeReplyObject(r);
             return NULL;
         }
     }
@@ -228,7 +228,7 @@ static void *createDoubleObject(const valkeyReadTask *task, double value, char *
     r->dval = value;
     r->str = vk_malloc(len + 1);
     if (r->str == NULL) {
-        freeReplyObject(r);
+        valkeyFreeReplyObject(r);
         return NULL;
     }
 
@@ -715,7 +715,7 @@ valkeyReader *valkeyReaderCreate(void) {
 
 static void valkeyPushAutoFree(void *privdata, void *reply) {
     (void)privdata;
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 static valkeyContext *valkeyContextInit(void) {
@@ -866,7 +866,7 @@ valkeyContext *valkeyConnectWithOptions(const valkeyOptions *options) {
         c->flags |= VALKEY_MPTCP;
     }
 
-    /* Set any user supplied RESP3 PUSH handler or use freeReplyObject
+    /* Set any user supplied RESP3 PUSH handler or use valkeyFreeReplyObject
      * as a default unless specifically flagged that we don't want one. */
     if (options->push_cb != NULL)
         valkeySetPushCallback(c, options->push_cb);
@@ -1143,7 +1143,7 @@ int valkeyGetReply(valkeyContext *c, void **reply) {
     if (reply != NULL) {
         *reply = aux;
     } else {
-        freeReplyObject(aux);
+        valkeyFreeReplyObject(aux);
     }
 
     return VALKEY_OK;

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -186,11 +186,11 @@ void get_server_version(valkeyContext *c, int *majorptr, int *minorptr) {
     if (minorptr)
         *minorptr = minor;
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     return;
 
 abort:
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     fprintf(stderr, "Error:  Cannot determine server version, aborting\n");
     exit(1);
 }
@@ -201,14 +201,14 @@ static valkeyContext *select_database(valkeyContext *c) {
     /* Switch to DB 9 for testing, now that we know we can chat. */
     reply = valkeyCommand(c, "SELECT 9");
     assert(reply != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Make sure the DB is empty */
     reply = valkeyCommand(c, "DBSIZE");
     assert(reply != NULL);
     if (reply->type == VALKEY_REPLY_INTEGER && reply->integer == 0) {
         /* Awesome, DB 9 is empty and we can continue. */
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     } else {
         printf("Database #9 is not empty, test cannot continue\n");
         exit(1);
@@ -225,7 +225,7 @@ static void send_hello(valkeyContext *c, int version) {
     reply = valkeyCommand(c, "HELLO %d", version);
     expected = version == 3 ? VALKEY_REPLY_MAP : VALKEY_REPLY_ARRAY;
     assert(reply != NULL && reply->type == expected);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 /* Toggle client tracking */
@@ -234,7 +234,7 @@ static void send_client_tracking(valkeyContext *c, const char *str) {
 
     reply = valkeyCommand(c, "CLIENT TRACKING %s", str);
     assert(reply != NULL && reply->type == VALKEY_REPLY_STATUS);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 static int disconnect(valkeyContext *c, int keep_fd) {
@@ -243,10 +243,10 @@ static int disconnect(valkeyContext *c, int keep_fd) {
     /* Make sure we're on DB 9. */
     reply = valkeyCommand(c, "SELECT 9");
     assert(reply != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     reply = valkeyCommand(c, "FLUSHDB");
     assert(reply != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Free the context as well, but keep the fd if requested. */
     if (keep_fd)
@@ -484,7 +484,7 @@ static void test_append_formatted_commands(struct config config) {
     assert(valkeyGetReply(c, (void *)&reply) == VALKEY_OK);
 
     vk_free(cmd);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     disconnect(c, 0);
 }
@@ -521,7 +521,7 @@ static void test_unix_keepalive(struct config cfg) {
     r = valkeyCommand(c, "PING");
     test_cond(r != NULL && r->type == VALKEY_REPLY_STATUS && r->len == 4 &&
               !memcmp(r->str, "PONG", 4));
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     valkeyFree(c);
 }
@@ -571,7 +571,7 @@ static void test_reply_reader(void) {
     }
     test_cond(((valkeyReply *)reply)->type == VALKEY_REPLY_STRING &&
               !memcmp(((valkeyReply *)reply)->str, "LOLWUT", 6));
-    freeReplyObject(root);
+    valkeyFreeReplyObject(root);
     valkeyReaderFree(reader);
 
     test("Correctly parses LLONG_MAX: ");
@@ -581,7 +581,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_INTEGER &&
               ((valkeyReply *)reply)->integer == LLONG_MAX);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error when > LLONG_MAX: ");
@@ -590,7 +590,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Bad integer value") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Correctly parses LLONG_MIN: ");
@@ -600,7 +600,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_INTEGER &&
               ((valkeyReply *)reply)->integer == LLONG_MIN);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error when < LLONG_MIN: ");
@@ -609,7 +609,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Bad integer value") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error when array < -1: ");
@@ -618,7 +618,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error when bulk < -1: ");
@@ -627,7 +627,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Bulk string length out of range") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can configure maximum multi-bulk elements: ");
@@ -637,7 +637,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Multi-bulk never overflows regardless of maxelements: ");
@@ -651,7 +651,7 @@ static void test_reply_reader(void) {
     valkeyReaderFeed(reader, bad_mbulk_reply, strlen(bad_mbulk_reply));
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR && strcasecmp(reader->errstr, "Out of memory") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
 #if LLONG_MAX > SIZE_MAX
@@ -661,7 +661,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Multi-bulk length out of range") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error when bulk > SIZE_MAX: ");
@@ -670,7 +670,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Bulk string length out of range") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 #endif
 
@@ -713,7 +713,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_ARRAY &&
               ((valkeyReply *)reply)->elements == 3);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     /* Regression test for issue #45 on GitHub. */
@@ -724,7 +724,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_ARRAY &&
               ((valkeyReply *)reply)->elements == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     /* RESP3 verbatim strings (GitHub issue #802) */
@@ -735,7 +735,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_VERB &&
               !memcmp(((valkeyReply *)reply)->str, "LOLWUT", 6));
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     /* RESP3 push messages (GitHub issue #815) */
@@ -750,7 +750,7 @@ static void test_reply_reader(void) {
               !memcmp(((valkeyReply *)reply)->element[0]->str, "LOLWUT", 6) &&
               ((valkeyReply *)reply)->element[1]->type == VALKEY_REPLY_INTEGER &&
               ((valkeyReply *)reply)->element[1]->integer == 42);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 doubles: ");
@@ -762,7 +762,7 @@ static void test_reply_reader(void) {
               fabs(((valkeyReply *)reply)->dval - 3.14159265358979323846) < 0.00000001 &&
               ((valkeyReply *)reply)->len == 22 &&
               strcmp(((valkeyReply *)reply)->str, "3.14159265358979323846") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error on invalid RESP3 double: ");
@@ -771,7 +771,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Bad double value") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Correctly parses RESP3 double INFINITY: ");
@@ -782,7 +782,7 @@ static void test_reply_reader(void) {
               ((valkeyReply *)reply)->type == VALKEY_REPLY_DOUBLE &&
               isinf(((valkeyReply *)reply)->dval) &&
               ((valkeyReply *)reply)->dval > 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Correctly parses RESP3 double NaN: ");
@@ -792,7 +792,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_DOUBLE &&
               isnan(((valkeyReply *)reply)->dval));
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Correctly parses RESP3 double -Nan: ");
@@ -802,7 +802,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_DOUBLE &&
               isnan(((valkeyReply *)reply)->dval));
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 nil: ");
@@ -811,7 +811,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_NIL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error on invalid RESP3 nil: ");
@@ -820,7 +820,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Bad nil value") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 bool (true): ");
@@ -830,7 +830,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_BOOL &&
               ((valkeyReply *)reply)->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 bool (false): ");
@@ -840,7 +840,7 @@ static void test_reply_reader(void) {
     test_cond(ret == VALKEY_OK &&
               ((valkeyReply *)reply)->type == VALKEY_REPLY_BOOL &&
               !((valkeyReply *)reply)->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Set error on invalid RESP3 bool: ");
@@ -849,7 +849,7 @@ static void test_reply_reader(void) {
     ret = valkeyReaderGetReply(reader, &reply);
     test_cond(ret == VALKEY_ERR &&
               strcasecmp(reader->errstr, "Bad bool value") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 map: ");
@@ -869,7 +869,7 @@ static void test_reply_reader(void) {
               !strcmp(((valkeyReply *)reply)->element[2]->str, "second") &&
               ((valkeyReply *)reply)->element[3]->type == VALKEY_REPLY_BOOL &&
               ((valkeyReply *)reply)->element[3]->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     /* RESP3 MAP/ATTR types double the element count being key-value pairs */
@@ -899,7 +899,7 @@ static void test_reply_reader(void) {
               !strcmp(((valkeyReply *)reply)->element[2]->str, "bar") &&
               ((valkeyReply *)reply)->element[3]->type == VALKEY_REPLY_BOOL &&
               ((valkeyReply *)reply)->element[3]->integer);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 set: ");
@@ -921,7 +921,7 @@ static void test_reply_reader(void) {
               ((valkeyReply *)reply)->element[3]->integer == 100 &&
               ((valkeyReply *)reply)->element[4]->type == VALKEY_REPLY_INTEGER &&
               ((valkeyReply *)reply)->element[4]->integer == 999);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 bignum: ");
@@ -932,7 +932,7 @@ static void test_reply_reader(void) {
               ((valkeyReply *)reply)->type == VALKEY_REPLY_BIGNUM &&
               ((valkeyReply *)reply)->len == 43 &&
               !strcmp(((valkeyReply *)reply)->str, "3492890328409238509324850943850943825024385"));
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 
     test("Can parse RESP3 doubles in an array: ");
@@ -946,7 +946,7 @@ static void test_reply_reader(void) {
               fabs(((valkeyReply *)reply)->element[0]->dval - 3.14159265358979323846) < 0.00000001 &&
               ((valkeyReply *)reply)->element[0]->len == 22 &&
               strcmp(((valkeyReply *)reply)->element[0]->str, "3.14159265358979323846") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyReaderFree(reader);
 }
 
@@ -958,8 +958,8 @@ static void test_free_null(void) {
     valkeyFree(valkeyCtx);
     test_cond(valkeyCtx == NULL);
 
-    test("Don't fail when freeReplyObject is passed a NULL value: ");
-    freeReplyObject(reply);
+    test("Don't fail when valkeyFreeReplyObject is passed a NULL value: ");
+    valkeyFreeReplyObject(reply);
     test_cond(reply == NULL);
 }
 
@@ -1125,7 +1125,7 @@ void push_handler(void *privdata, void *r) {
         pcounts->nil++;
     }
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 /* Dummy function just to test setting a callback with valkeyOptions */
@@ -1148,15 +1148,15 @@ static void test_resp3_push_handler(valkeyContext *c) {
 
     reply = valkeyCommand(c, "GET key:0");
     assert(reply != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("RESP3 PUSH messages are handled out of band by default: ");
     reply = valkeyCommand(c, "SET key:0 val:0");
     test_cond(reply != NULL && reply->type == VALKEY_REPLY_STATUS);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert((reply = valkeyCommand(c, "GET key:0")) != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     old = valkeySetPushCallback(c, push_handler);
     test("We can set a custom RESP3 PUSH handler: ");
@@ -1164,39 +1164,39 @@ static void test_resp3_push_handler(valkeyContext *c) {
     /* We need another command because depending on the server version, the
      * notification may be delivered after the command's reply. */
     assert(reply != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     reply = valkeyCommand(c, "PING");
     test_cond(reply != NULL && reply->type == VALKEY_REPLY_STATUS && pc.str == 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("We properly handle a NIL invalidation payload: ");
     reply = valkeyCommand(c, "FLUSHDB");
     assert(reply != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     reply = valkeyCommand(c, "PING");
     test_cond(reply != NULL && reply->type == VALKEY_REPLY_STATUS && pc.nil == 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Unset the push callback and generate an invalidate message making
      * sure it is not handled out of band. */
     test("With no handler, PUSH replies come in-band: ");
     valkeySetPushCallback(c, NULL);
     assert((reply = valkeyCommand(c, "GET key:0")) != NULL);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     assert((reply = valkeyCommand(c, "SET key:0 invalid")) != NULL);
     /* Depending on server version, we may receive either push notification or
      * status reply. Both cases are valid. */
     if (reply->type == VALKEY_REPLY_STATUS) {
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyCommand(c, "PING");
     }
     test_cond(reply->type == VALKEY_REPLY_PUSH);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("With no PUSH handler, no replies are lost: ");
     assert(valkeyGetReply(c, (void **)&reply) == VALKEY_OK);
     test_cond(reply != NULL && reply->type == VALKEY_REPLY_STATUS);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Return to the originally set PUSH handler */
     assert(old != NULL);
@@ -1291,60 +1291,60 @@ static void test_blocking_connection(struct config config) {
     reply = valkeyCommand(c, "PING");
     test_cond(reply->type == VALKEY_REPLY_STATUS &&
               strcasecmp(reply->str, "pong") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("Is a able to send commands verbatim: ");
     reply = valkeyCommand(c, "SET foo bar");
     test_cond(reply->type == VALKEY_REPLY_STATUS &&
               strcasecmp(reply->str, "ok") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("%%s String interpolation works: ");
     reply = valkeyCommand(c, "SET %s %s", "foo", "hello world");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     reply = valkeyCommand(c, "GET foo");
     test_cond(reply->type == VALKEY_REPLY_STRING &&
               strcmp(reply->str, "hello world") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("%%b String interpolation works: ");
     reply = valkeyCommand(c, "SET %b %b", "foo", (size_t)3, "hello\x00world", (size_t)11);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     reply = valkeyCommand(c, "GET foo");
     test_cond(reply->type == VALKEY_REPLY_STRING &&
               memcmp(reply->str, "hello\x00world", 11) == 0);
 
     test("Binary reply length is correct: ");
     test_cond(reply->len == 11)
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
     test("Can parse nil replies: ");
     reply = valkeyCommand(c, "GET nokey");
     test_cond(reply->type == VALKEY_REPLY_NIL)
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
     /* test 7 */
     test("Can parse integer replies: ");
     reply = valkeyCommand(c, "INCR mycounter");
     test_cond(reply->type == VALKEY_REPLY_INTEGER && reply->integer == 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("Can parse multi bulk replies: ");
-    freeReplyObject(valkeyCommand(c, "LPUSH mylist foo"));
-    freeReplyObject(valkeyCommand(c, "LPUSH mylist bar"));
+    valkeyFreeReplyObject(valkeyCommand(c, "LPUSH mylist foo"));
+    valkeyFreeReplyObject(valkeyCommand(c, "LPUSH mylist bar"));
     reply = valkeyCommand(c, "LRANGE mylist 0 -1");
     test_cond(reply->type == VALKEY_REPLY_ARRAY &&
               reply->elements == 2 &&
               !memcmp(reply->element[0]->str, "bar", 3) &&
               !memcmp(reply->element[1]->str, "foo", 3));
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* m/e with multi bulk reply *before* other reply.
      * specifically test ordering of reply items to parse. */
     test("Can handle nested multi bulk replies: ");
-    freeReplyObject(valkeyCommand(c, "MULTI"));
-    freeReplyObject(valkeyCommand(c, "LRANGE mylist 0 -1"));
-    freeReplyObject(valkeyCommand(c, "PING"));
+    valkeyFreeReplyObject(valkeyCommand(c, "MULTI"));
+    valkeyFreeReplyObject(valkeyCommand(c, "LRANGE mylist 0 -1"));
+    valkeyFreeReplyObject(valkeyCommand(c, "PING"));
     reply = (valkeyCommand(c, "EXEC"));
     test_cond(reply->type == VALKEY_REPLY_ARRAY &&
               reply->elements == 2 &&
@@ -1354,14 +1354,14 @@ static void test_blocking_connection(struct config config) {
               !memcmp(reply->element[0]->element[1]->str, "foo", 3) &&
               reply->element[1]->type == VALKEY_REPLY_STATUS &&
               strcasecmp(reply->element[1]->str, "pong") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("Send command by passing argc/argv: ");
     const char *argv[3] = {"SET", "foo", "bar"};
     size_t argvlen[3] = {3, 3, 3};
     reply = valkeyCommandArgv(c, 3, argv, argvlen);
     test_cond(reply->type == VALKEY_REPLY_STATUS);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Make sure passing NULL to valkeyGetReply is safe */
     test("Can pass NULL to valkeyGetReply: ");
@@ -1390,7 +1390,7 @@ static int detect_debug_sleep(valkeyContext *c) {
     }
 
     detected = reply->type == VALKEY_REPLY_STATUS;
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     return detected;
 }
@@ -1405,11 +1405,11 @@ static void test_blocking_connection_timeouts(struct config config) {
     c = do_connect(config);
     test("Successfully completes a command when the timeout is not exceeded: ");
     reply = valkeyCommand(c, "SET foo fast");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeySetTimeout(c, tv);
     reply = valkeyCommand(c, "GET foo");
     test_cond(reply != NULL && reply->type == VALKEY_REPLY_STRING && memcmp(reply->str, "fast", 4) == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     disconnect(c, 0);
 
     c = do_connect(config);
@@ -1432,7 +1432,7 @@ static void test_blocking_connection_timeouts(struct config config) {
         test_cond(s > 0 && reply == NULL && c->err == VALKEY_ERR_TIMEOUT &&
                   strcmp(c->errstr, "recv timeout") == 0);
 #endif
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
         // wait for the DEBUG SLEEP to complete so that the server is unblocked for the following tests
         millisleep(1500);
@@ -1444,7 +1444,7 @@ static void test_blocking_connection_timeouts(struct config config) {
     do_reconnect(c, config);
     reply = valkeyCommand(c, "PING");
     test_cond(reply != NULL && reply->type == VALKEY_REPLY_STATUS && strcmp(reply->str, "PONG") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     test("Reconnect properly uses owned parameters: ");
     config.tcp.host = "foo";
@@ -1452,7 +1452,7 @@ static void test_blocking_connection_timeouts(struct config config) {
     do_reconnect(c, config);
     reply = valkeyCommand(c, "PING");
     test_cond(reply != NULL && reply->type == VALKEY_REPLY_STATUS && strcmp(reply->str, "PONG") == 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     disconnect(c, 0);
 }
@@ -1474,7 +1474,7 @@ static void test_blocking_io_errors(struct config config) {
          * to know the descriptor is at EOF. */
         test_cond(strcasecmp(reply->str, "OK") == 0 &&
                   valkeyGetReply(c, &_reply) == VALKEY_ERR);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     } else {
         test_cond(reply == NULL);
     }
@@ -1571,7 +1571,7 @@ static void test_throughput(struct config config) {
 
     test("Throughput:\n");
     for (i = 0; i < 500; i++)
-        freeReplyObject(valkeyCommand(c, "LPUSH mylist foo"));
+        valkeyFreeReplyObject(valkeyCommand(c, "LPUSH mylist foo"));
 
     num = 1000;
     replies = vk_malloc_safe(sizeof(valkeyReply *) * num);
@@ -1582,7 +1582,7 @@ static void test_throughput(struct config config) {
     }
     t2 = usec();
     for (i = 0; i < num; i++)
-        freeReplyObject(replies[i]);
+        valkeyFreeReplyObject(replies[i]);
     vk_free(replies);
     printf("\t(%dx PING: %.3fs)\n", num, (t2 - t1) / 1000000.0);
 
@@ -1595,7 +1595,7 @@ static void test_throughput(struct config config) {
     }
     t2 = usec();
     for (i = 0; i < num; i++)
-        freeReplyObject(replies[i]);
+        valkeyFreeReplyObject(replies[i]);
     vk_free(replies);
     printf("\t(%dx LRANGE with 500 elements: %.3fs)\n", num, (t2 - t1) / 1000000.0);
 
@@ -1607,7 +1607,7 @@ static void test_throughput(struct config config) {
     }
     t2 = usec();
     for (i = 0; i < num; i++)
-        freeReplyObject(replies[i]);
+        valkeyFreeReplyObject(replies[i]);
     vk_free(replies);
     printf("\t(%dx INCRBY: %.3fs)\n", num, (t2 - t1) / 1000000.0);
 
@@ -1622,7 +1622,7 @@ static void test_throughput(struct config config) {
     }
     t2 = usec();
     for (i = 0; i < num; i++)
-        freeReplyObject(replies[i]);
+        valkeyFreeReplyObject(replies[i]);
     vk_free(replies);
     printf("\t(%dx PING (pipelined): %.3fs)\n", num, (t2 - t1) / 1000000.0);
 
@@ -1637,7 +1637,7 @@ static void test_throughput(struct config config) {
     }
     t2 = usec();
     for (i = 0; i < num; i++)
-        freeReplyObject(replies[i]);
+        valkeyFreeReplyObject(replies[i]);
     vk_free(replies);
     printf("\t(%dx LRANGE with 500 elements (pipelined): %.3fs)\n", num, (t2 - t1) / 1000000.0);
 
@@ -1651,7 +1651,7 @@ static void test_throughput(struct config config) {
     }
     t2 = usec();
     for (i = 0; i < num; i++)
-        freeReplyObject(replies[i]);
+        valkeyFreeReplyObject(replies[i]);
     vk_free(replies);
     printf("\t(%dx INCRBY (pipelined): %.3fs)\n", num, (t2 - t1) / 1000000.0);
 
@@ -1700,7 +1700,7 @@ void publish_msg(valkeyOptions *options, const char *channel, const char *msg) {
     assert(c != NULL);
     valkeyReply *reply = valkeyCommand(c, "PUBLISH %s %s", channel, msg);
     assert(reply->type == VALKEY_REPLY_INTEGER && reply->integer == 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     disconnect(c, 0);
 }
 
@@ -1710,7 +1710,7 @@ void spublish_msg(valkeyOptions *options, const char *channel, const char *msg) 
     assert(c != NULL);
     valkeyReply *reply = valkeyCommand(c, "SPUBLISH %s %s", channel, msg);
     assert(reply->type == VALKEY_REPLY_INTEGER && reply->integer == 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     disconnect(c, 0);
 }
 
@@ -2365,7 +2365,7 @@ void monitor_cb(valkeyAsyncContext *ac, void *r, void *privdata) {
         assert(c != NULL);
         valkeyReply *reply = valkeyCommand(c, "SET first 1");
         assert(reply->type == VALKEY_REPLY_STATUS);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         valkeyFree(c);
     } else if (state->checkpoint == 2) {
         /* Response for monitored command 'SET first 1' */
@@ -2374,7 +2374,7 @@ void monitor_cb(valkeyAsyncContext *ac, void *r, void *privdata) {
         assert(c != NULL);
         valkeyReply *reply = valkeyCommand(c, "SET second 2");
         assert(reply->type == VALKEY_REPLY_STATUS);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         valkeyFree(c);
     } else if (state->checkpoint == 3) {
         /* Response for monitored command 'SET second 2' */

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
                 } else {
                     printReply(reply);
                 }
-                freeReplyObject(reply);
+                valkeyFreeReplyObject(reply);
                 if (route_version != cc->route_version) {
                     /* Updated slotmap resets the iterator. Abort iteration. */
                     break;
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
             } else {
                 printReply(reply);
             }
-            freeReplyObject(reply);
+            valkeyFreeReplyObject(reply);
         }
     }
 

--- a/tests/ct_commands.c
+++ b/tests/ct_commands.c
@@ -13,23 +13,23 @@ void test_exists(valkeyClusterContext *cc) {
     valkeyReply *reply;
     reply = valkeyClusterCommand(cc, "SET {key}1 Hello");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "EXISTS {key}1");
     CHECK_REPLY_INT(cc, reply, 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "EXISTS nosuch{key}");
     CHECK_REPLY_INT(cc, reply, 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "SET {key}2 World");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "EXISTS {key}1 {key}2 nosuch{key}");
     CHECK_REPLY_INT(cc, reply, 2);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_bitfield(valkeyClusterContext *cc) {
@@ -39,7 +39,7 @@ void test_bitfield(valkeyClusterContext *cc) {
         cc, "BITFIELD bkey1 SET u32 #0 255 GET u32 #0");
     CHECK_REPLY_ARRAY(cc, reply, 2);
     CHECK_REPLY_INT(cc, reply->element[1], 255);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_bitfield_ro(valkeyClusterContext *cc) {
@@ -50,13 +50,13 @@ void test_bitfield_ro(valkeyClusterContext *cc) {
 
     reply = (valkeyReply *)valkeyClusterCommand(cc, "SET bkey2 a"); // 97
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply =
         (valkeyReply *)valkeyClusterCommand(cc, "BITFIELD_RO bkey2 GET u8 #0");
     CHECK_REPLY_ARRAY(cc, reply, 1);
     CHECK_REPLY_INT(cc, reply->element[0], 97);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_mset(valkeyClusterContext *cc) {
@@ -64,41 +64,41 @@ void test_mset(valkeyClusterContext *cc) {
     reply =
         valkeyClusterCommand(cc, "MSET {key}1 mset1 {key}2 mset2 {key}3 mset3");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "GET {key}1");
     CHECK_REPLY_STR(cc, reply, "mset1");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "GET {key}2");
     CHECK_REPLY_STR(cc, reply, "mset2");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "GET {key}3");
     CHECK_REPLY_STR(cc, reply, "mset3");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_mget(valkeyClusterContext *cc) {
     valkeyReply *reply;
     reply = valkeyClusterCommand(cc, "SET {key}1 mget1");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "SET {key}2 mget2");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "SET {key}3 mget3");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc, "MGET {key}1 {key}2 {key}3");
     CHECK_REPLY_ARRAY(cc, reply, 3);
     CHECK_REPLY_STR(cc, reply->element[0], "mget1");
     CHECK_REPLY_STR(cc, reply->element[1], "mget2");
     CHECK_REPLY_STR(cc, reply->element[2], "mget3");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_hset_hget_hdel_hexists(valkeyClusterContext *cc) {
@@ -107,64 +107,64 @@ void test_hset_hget_hdel_hexists(valkeyClusterContext *cc) {
     // Prepare
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HDEL myhash field1");
     CHECK_REPLY(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HDEL myhash field2");
     CHECK_REPLY(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Set hash field
     reply =
         (valkeyReply *)valkeyClusterCommand(cc, "HSET myhash field1 hsetvalue");
     CHECK_REPLY_INT(cc, reply, 1); // Set 1 field
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Set second hash field
     reply = (valkeyReply *)valkeyClusterCommand(
         cc, "HSET myhash field3 hsetvalue3");
     CHECK_REPLY_INT(cc, reply, 1); // Set 1 field
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Get field value
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HGET myhash field1");
     CHECK_REPLY_STR(cc, reply, "hsetvalue");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Get field that is not present
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HGET myhash field2");
     CHECK_REPLY_NIL(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Delete a field
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HDEL myhash field1");
     CHECK_REPLY_INT(cc, reply, 1); // Delete 1 field
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Delete a field that is not present
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HDEL myhash field2");
     CHECK_REPLY_INT(cc, reply, 0); // Nothing to delete
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Check if field exists
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HEXISTS myhash field3");
     CHECK_REPLY_INT(cc, reply, 1); // exists
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Delete multiple fields at once
     reply = (valkeyReply *)valkeyClusterCommand(
         cc, "HDEL myhash field1 field2 field3");
     CHECK_REPLY_INT(cc, reply, 1); // field3 deleted
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Make sure field3 is deleted now
     reply = (valkeyReply *)valkeyClusterCommand(cc, "HEXISTS myhash field3");
     CHECK_REPLY_INT(cc, reply, 0); // no field
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Set multiple fields at once
     reply = (valkeyReply *)valkeyClusterCommand(
         cc, "HSET myhash field1 hsetvalue1 field2 hsetvalue2");
     CHECK_REPLY_INT(cc, reply, 2);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 // Command layout:
@@ -176,13 +176,13 @@ void test_eval(valkeyClusterContext *cc) {
     reply = (valkeyReply *)valkeyClusterCommand(
         cc, "eval %s 1 %s", "return redis.call('set',KEYS[1],'bar')", "foo");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Single key, string response
     reply = (valkeyReply *)valkeyClusterCommand(cc, "eval %s 1 %s",
                                                 "return KEYS[1]", "key1");
     CHECK_REPLY_STR(cc, reply, "key1");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Single key with single argument
     reply = (valkeyReply *)valkeyClusterCommand(
@@ -190,7 +190,7 @@ void test_eval(valkeyClusterContext *cc) {
     CHECK_REPLY_ARRAY(cc, reply, 2);
     CHECK_REPLY_STR(cc, reply->element[0], "key1");
     CHECK_REPLY_STR(cc, reply->element[1], "first");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Multi key, but handled by same instance
     reply = (valkeyReply *)valkeyClusterCommand(
@@ -198,7 +198,7 @@ void test_eval(valkeyClusterContext *cc) {
     CHECK_REPLY_ARRAY(cc, reply, 2);
     CHECK_REPLY_STR(cc, reply->element[0], "key1");
     CHECK_REPLY_STR(cc, reply->element[1], "key1");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Error handling in EVAL
 
@@ -211,11 +211,11 @@ void test_eval(valkeyClusterContext *cc) {
     // to access it as a simple type.
     reply = (valkeyReply *)valkeyClusterCommand(cc, "del foo");
     CHECK_REPLY_INT(cc, reply, 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = (valkeyReply *)valkeyClusterCommand(cc, "lpush foo a");
     CHECK_REPLY_INT(cc, reply, 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = (valkeyReply *)valkeyClusterCommand(
         cc, "eval %s 1 %s", "return redis.call('get',KEYS[1])", "foo");
@@ -224,7 +224,7 @@ void test_eval(valkeyClusterContext *cc) {
     } else {
         CHECK_REPLY_ERROR(cc, reply, "WRONGTYPE");
     }
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Two keys handled by different instances,
     // will fail due to CROSSSLOT.
@@ -232,7 +232,7 @@ void test_eval(valkeyClusterContext *cc) {
         cc, "eval %s 2 %s %s %s %s", "return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}",
         "key1", "key2", "first", "second");
     CHECK_REPLY_ERROR(cc, reply, "CROSSSLOT");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_xack(valkeyClusterContext *cc) {
@@ -241,17 +241,17 @@ void test_xack(valkeyClusterContext *cc) {
     /* Prepare a stream and group */
     r = valkeyClusterCommand(cc, "XADD mystream * field1 value1");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_STRING);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
     r = valkeyClusterCommand(cc, "XGROUP DESTROY mystream mygroup");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
     r = valkeyClusterCommand(cc, "XGROUP CREATE mystream mygroup 0");
     CHECK_REPLY_OK(cc, r);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XACK mystream mygroup 1526569495631-0");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xadd(valkeyClusterContext *cc) {
@@ -259,16 +259,16 @@ void test_xadd(valkeyClusterContext *cc) {
 
     r = valkeyClusterCommand(cc, "XADD mystream * field1 value1");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_STRING);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XADD mystream * field1 value1 field2 value2");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_STRING);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(
         cc, "XADD mystream * field1 value1 field2 value2 field3 value3");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_STRING);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xautoclaim(valkeyClusterContext *cc) {
@@ -280,7 +280,7 @@ void test_xautoclaim(valkeyClusterContext *cc) {
     r = valkeyClusterCommand(
         cc, "XAUTOCLAIM mystream mygroup Alice 3600000 0-0 COUNT 25");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xclaim(valkeyClusterContext *cc) {
@@ -289,7 +289,7 @@ void test_xclaim(valkeyClusterContext *cc) {
     r = valkeyClusterCommand(
         cc, "XCLAIM mystream mygroup Alice 3600000 1526569498055-0");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xdel(valkeyClusterContext *cc) {
@@ -299,16 +299,16 @@ void test_xdel(valkeyClusterContext *cc) {
     r = valkeyClusterCommand(cc, "XADD mystream * field value");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_STRING);
     id = strdup(r->str); /* Keep the id */
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XDEL mystream %s", id);
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     /* Verify client handling of multiple id values / arguments */
     r = valkeyClusterCommand(cc, "XDEL mystream %s %s", id, id);
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     free(id);
 }
@@ -327,18 +327,18 @@ void test_xgroup(valkeyClusterContext *cc) {
     /* Test the destroy command first as preparation */
     r = valkeyClusterCommand(cc, "XGROUP DESTROY mystream consumer-group-name");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc,
                              "XGROUP CREATE mystream consumer-group-name 0");
     CHECK_REPLY_OK(cc, r);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     /* Attempting to create an already existing group gives error */
     r = valkeyClusterCommand(cc,
                              "XGROUP CREATE mystream consumer-group-name 0");
     CHECK_REPLY_ERROR(cc, r, "BUSYGROUP");
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     if (!valkey_version_less_than(6, 2)) {
         /* Test of subcommand CREATECONSUMER when available. */
@@ -346,17 +346,17 @@ void test_xgroup(valkeyClusterContext *cc) {
             cc,
             "XGROUP CREATECONSUMER mystream consumer-group-name myconsumer123");
         CHECK_REPLY_INT(cc, r, 1);
-        freeReplyObject(r);
+        valkeyFreeReplyObject(r);
     }
 
     r = valkeyClusterCommand(
         cc, "XGROUP DELCONSUMER mystream consumer-group-name myconsumer123");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XGROUP SETID mystream consumer-group-name 0");
     CHECK_REPLY_OK(cc, r);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xinfo(valkeyClusterContext *cc) {
@@ -372,23 +372,23 @@ void test_xinfo(valkeyClusterContext *cc) {
 
     r = valkeyClusterCommand(cc, "XINFO STREAM mystream");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     if (!valkey_version_less_than(6, 0)) {
         /* Test of subcommand STREAM with arguments when available. */
         r = valkeyClusterCommand(cc, "XINFO STREAM mystream FULL COUNT 1");
         CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-        freeReplyObject(r);
+        valkeyFreeReplyObject(r);
     }
 
     r = valkeyClusterCommand(cc, "XINFO GROUPS mystream");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc,
                              "XINFO CONSUMERS mystream consumer-group-name");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xlen(valkeyClusterContext *cc) {
@@ -396,7 +396,7 @@ void test_xlen(valkeyClusterContext *cc) {
 
     r = (valkeyReply *)valkeyClusterCommand(cc, "XLEN mystream");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xpending(valkeyClusterContext *cc) {
@@ -404,11 +404,11 @@ void test_xpending(valkeyClusterContext *cc) {
 
     r = valkeyClusterCommand(cc, "XPENDING mystream mygroup");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XPENDING mystream mygroup - + 10");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_ARRAY);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xrange(valkeyClusterContext *cc) {
@@ -416,11 +416,11 @@ void test_xrange(valkeyClusterContext *cc) {
 
     r = valkeyClusterCommand(cc, "XRANGE mystream 0 0");
     CHECK_REPLY_ARRAY(cc, r, 0); /* No entries due to 0-range */
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XRANGE mystream - + COUNT 1");
     CHECK_REPLY_ARRAY(cc, r, 1); /* Single entry due to count argument */
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xrevrange(valkeyClusterContext *cc) {
@@ -428,11 +428,11 @@ void test_xrevrange(valkeyClusterContext *cc) {
 
     r = valkeyClusterCommand(cc, "XREVRANGE mystream 0 0");
     CHECK_REPLY_ARRAY(cc, r, 0); /* No entries due to 0-range */
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XREVRANGE mystream + - COUNT 1");
     CHECK_REPLY_ARRAY(cc, r, 1); /* Single entry due to count argument */
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_xtrim(valkeyClusterContext *cc) {
@@ -440,11 +440,11 @@ void test_xtrim(valkeyClusterContext *cc) {
 
     r = valkeyClusterCommand(cc, "XTRIM mystream MAXLEN 200");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 
     r = valkeyClusterCommand(cc, "XTRIM mystream MAXLEN ~ 100");
     CHECK_REPLY_TYPE(r, VALKEY_REPLY_INTEGER);
-    freeReplyObject(r);
+    valkeyFreeReplyObject(r);
 }
 
 void test_multi(valkeyClusterContext *cc) {

--- a/tests/ct_connection.c
+++ b/tests/ct_connection.c
@@ -59,7 +59,7 @@ void test_password_ok(void) {
     valkeyReply *reply;
     reply = valkeyClusterCommand(cc, "SET key1 Hello");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     valkeyClusterFree(cc);
 
     // Check counters incremented by connect callback
@@ -121,7 +121,7 @@ void test_username_ok(void) {
     // Test connection
     valkeyReply *reply = valkeyClusterCommand(cc, "SET key1 Hello");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterFree(cc);
 }
@@ -146,20 +146,20 @@ void test_multicluster(void) {
     // Set keys differently in clusters
     reply = valkeyClusterCommand(cc1, "SET key Hello1");
     CHECK_REPLY_OK(cc1, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc2, "SET key Hello2");
     CHECK_REPLY_OK(cc2, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Verify keys in clusters
     reply = valkeyClusterCommand(cc1, "GET key");
     CHECK_REPLY_STR(cc1, reply, "Hello1");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommand(cc2, "GET key");
     CHECK_REPLY_STR(cc2, reply, "Hello2");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     // Disconnect from first cluster
     valkeyClusterFree(cc1);
@@ -167,7 +167,7 @@ void test_multicluster(void) {
     // Verify that key is still accessible in connected cluster
     reply = valkeyClusterCommand(cc2, "GET key");
     CHECK_REPLY_STR(cc2, reply, "Hello2");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterFree(cc2);
 }
@@ -222,7 +222,7 @@ void test_command_timeout(void) {
             break;
     }
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterFree(cc);
 }
@@ -240,7 +240,7 @@ void test_command_timeout_set_while_connected(void) {
     valkeyReply *reply;
     reply = valkeyClusterCommandToNode(cc, node, "DEBUG SLEEP 0.2");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Set command timeout while connected */
     struct timeval timeout = {0, 10000};
@@ -257,7 +257,7 @@ void test_command_timeout_set_while_connected(void) {
             break;
     }
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterFree(cc);
 }

--- a/tests/ct_connection_ipv6.c
+++ b/tests/ct_connection_ipv6.c
@@ -22,11 +22,11 @@ void test_successful_ipv6_connection(void) {
     valkeyReply *reply;
     reply = (valkeyReply *)valkeyClusterCommand(cc, "SET key_ipv6 value");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = (valkeyReply *)valkeyClusterCommand(cc, "GET key_ipv6");
     CHECK_REPLY_STR(cc, reply, "value");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterFree(cc);
 }

--- a/tests/ct_out_of_memory_handling.c
+++ b/tests/ct_out_of_memory_handling.c
@@ -150,7 +150,7 @@ void test_alloc_failure_handling(void) {
         }
         assert(n < 1000);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 
     // Command to node
@@ -171,7 +171,7 @@ void test_alloc_failure_handling(void) {
         }
         assert(n < 1000);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 
     // Append command
@@ -209,7 +209,7 @@ void test_alloc_failure_handling(void) {
         }
         assert(ng < 1000);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 
     // Append command to node
@@ -248,7 +248,7 @@ void test_alloc_failure_handling(void) {
         }
         assert(ng < 1000);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 
     // Redirects
@@ -288,16 +288,16 @@ void test_alloc_failure_handling(void) {
                                            "CLUSTER SETSLOT %d MIGRATING %s",
                                            slot, replyDstId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyClusterCommandToNode(cc, dstNode,
                                            "CLUSTER SETSLOT %d IMPORTING %s",
                                            slot, replySrcId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyClusterCommandToNode(
             cc, srcNode, "MIGRATE 127.0.0.1 %d foo 0 5000", dstPort);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
         /* Test ASK reply handling with OOM */
         {
@@ -311,7 +311,7 @@ void test_alloc_failure_handling(void) {
             }
             assert(n < 1000);
             CHECK_REPLY_STR(cc, reply, "one");
-            freeReplyObject(reply);
+            valkeyFreeReplyObject(reply);
         }
 
         /* Finalize the migration. Skip OOM testing during these steps by
@@ -323,11 +323,11 @@ void test_alloc_failure_handling(void) {
         reply = valkeyClusterCommandToNode(
             cc, srcNode, "CLUSTER SETSLOT %d NODE %s", slot, replyDstId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyClusterCommandToNode(
             cc, dstNode, "CLUSTER SETSLOT %d NODE %s", slot, replyDstId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
         /* Test MOVED reply handling with OOM */
         {
@@ -341,7 +341,7 @@ void test_alloc_failure_handling(void) {
             }
             assert(n < 1000);
             CHECK_REPLY_STR(cc, reply, "one");
-            freeReplyObject(reply);
+            valkeyFreeReplyObject(reply);
         }
 
         /* MOVED triggers a slotmap update which currently replaces all cluster_node
@@ -357,27 +357,27 @@ void test_alloc_failure_handling(void) {
                                            "CLUSTER SETSLOT %d MIGRATING %s",
                                            slot, replySrcId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyClusterCommandToNode(cc, srcNode,
                                            "CLUSTER SETSLOT %d IMPORTING %s",
                                            slot, replyDstId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyClusterCommandToNode(
             cc, dstNode, "MIGRATE 127.0.0.1 %d foo 0 5000", srcPort);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyClusterCommandToNode(
             cc, dstNode, "CLUSTER SETSLOT %d NODE %s", slot, replySrcId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
         reply = valkeyClusterCommandToNode(
             cc, srcNode, "CLUSTER SETSLOT %d NODE %s", slot, replySrcId->str);
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
-        freeReplyObject(replySrcId);
-        freeReplyObject(replyDstId);
+        valkeyFreeReplyObject(replySrcId);
+        valkeyFreeReplyObject(replyDstId);
     }
 
     valkeyClusterFree(cc);

--- a/tests/ct_pipeline.c
+++ b/tests/ct_pipeline.c
@@ -33,23 +33,23 @@ void test_pipeline(void) {
     valkeyReply *reply;
     valkeyClusterGetReply(cc, (void *)&reply); // reply for: SET foo one
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterGetReply(cc, (void *)&reply); // reply for: SET bar two
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterGetReply(cc, (void *)&reply); // reply for: GET foo
     CHECK_REPLY_STR(cc, reply, "one");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterGetReply(cc, (void *)&reply); // reply for: GET bar
     CHECK_REPLY_STR(cc, reply, "two");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterGetReply(cc, (void *)&reply); // reply for: SUNION a b
     CHECK_REPLY_ERROR(cc, reply, "CROSSSLOT");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterFree(cc);
 }

--- a/tests/ct_specific_nodes.c
+++ b/tests/ct_specific_nodes.c
@@ -22,7 +22,7 @@ void test_command_to_single_node(valkeyClusterContext *cc) {
     reply = valkeyClusterCommandToNode(cc, node, "DBSIZE");
     CHECK_REPLY(cc, reply);
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_INTEGER);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_command_to_all_nodes(valkeyClusterContext *cc) {
@@ -37,7 +37,7 @@ void test_command_to_all_nodes(valkeyClusterContext *cc) {
         reply = valkeyClusterCommandToNode(cc, node, "DBSIZE");
         CHECK_REPLY(cc, reply);
         CHECK_REPLY_TYPE(reply, VALKEY_REPLY_INTEGER);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 }
 
@@ -49,21 +49,21 @@ void test_transaction(valkeyClusterContext *cc) {
     valkeyReply *reply;
     reply = valkeyClusterCommandToNode(cc, node, "MULTI");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommandToNode(cc, node, "SET foo 99");
     CHECK_REPLY_QUEUED(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommandToNode(cc, node, "INCR foo");
     CHECK_REPLY_QUEUED(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommandToNode(cc, node, "EXEC");
     CHECK_REPLY_ARRAY(cc, reply, 2);
     CHECK_REPLY_OK(cc, reply->element[0]);
     CHECK_REPLY_INT(cc, reply->element[1], 100);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_streams(valkeyClusterContext *cc) {
@@ -77,45 +77,45 @@ void test_streams(valkeyClusterContext *cc) {
     /* Preparation: remove old stream/key */
     reply = valkeyClusterCommandToNode(cc, node, "DEL mystream");
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_INTEGER);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Query wrong node */
     valkeyClusterNode *wrongNode = valkeyClusterGetNodeByKey(cc, (char *)"otherstream");
     assert(node != wrongNode);
     reply = valkeyClusterCommandToNode(cc, wrongNode, "XLEN mystream");
     CHECK_REPLY_ERROR(cc, reply, "MOVED");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Verify stream length before adding entries */
     reply = valkeyClusterCommandToNode(cc, node, "XLEN mystream");
     CHECK_REPLY_INT(cc, reply, 0);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Add entries to a created stream */
     reply = valkeyClusterCommandToNode(cc, node, "XADD mystream * name t800");
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_STRING);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     reply = valkeyClusterCommandToNode(
         cc, node, "XADD mystream * name Sara surname OConnor");
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_STRING);
     id = strdup(reply->str); /* Keep this id for later inspections */
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Verify stream length after adding entries */
     reply = valkeyClusterCommandToNode(cc, node, "XLEN mystream");
     CHECK_REPLY_INT(cc, reply, 2);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Modify the stream */
     reply = valkeyClusterCommandToNode(cc, node, "XTRIM mystream MAXLEN 1");
     CHECK_REPLY_INT(cc, reply, 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Verify stream length after modifying the stream */
     reply = valkeyClusterCommandToNode(cc, node, "XLEN mystream");
     CHECK_REPLY_INT(cc, reply, 1); /* 1 entry left */
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Read from the stream */
     reply = valkeyClusterCommandToNode(cc, node,
@@ -137,31 +137,31 @@ void test_streams(valkeyClusterContext *cc) {
     CHECK_REPLY_STR(cc, entry->element[1]->element[1], "Sara");
     CHECK_REPLY_STR(cc, entry->element[1]->element[2], "surname");
     CHECK_REPLY_STR(cc, entry->element[1]->element[3], "OConnor");
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Delete the entry in stream */
     reply = valkeyClusterCommandToNode(cc, node, "XDEL mystream %s", id);
     CHECK_REPLY_INT(cc, reply, 1);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Blocking read of stream */
     reply = valkeyClusterCommandToNode(
         cc, node, "XREAD COUNT 2 BLOCK 200 STREAMS mystream 0");
     CHECK_REPLY_NIL(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Create a consumer group */
     reply = valkeyClusterCommandToNode(cc, node,
                                        "XGROUP CREATE mystream mygroup1 0");
     CHECK_REPLY_OK(cc, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     if (!valkey_version_less_than(6, 2)) {
         /* Create a consumer */
         reply = valkeyClusterCommandToNode(
             cc, node, "XGROUP CREATECONSUMER mystream mygroup1 myconsumer123");
         CHECK_REPLY_INT(cc, reply, 1);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 
     /* Blocking read of consumer group */
@@ -170,7 +170,7 @@ void test_streams(valkeyClusterContext *cc) {
                                    "XREADGROUP GROUP mygroup1 myconsumer123 "
                                    "COUNT 2 BLOCK 200 STREAMS mystream 0");
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_ARRAY);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     free(id);
 }
@@ -191,7 +191,7 @@ void test_pipeline_to_single_node(valkeyClusterContext *cc) {
     valkeyClusterGetReply(cc, (void *)&reply);
     CHECK_REPLY(cc, reply);
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_INTEGER);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 }
 
 void test_pipeline_to_all_nodes(valkeyClusterContext *cc) {
@@ -210,17 +210,17 @@ void test_pipeline_to_all_nodes(valkeyClusterContext *cc) {
     valkeyClusterGetReply(cc, (void *)&reply);
     CHECK_REPLY(cc, reply);
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_INTEGER);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterGetReply(cc, (void *)&reply);
     CHECK_REPLY(cc, reply);
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_INTEGER);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterGetReply(cc, (void *)&reply);
     CHECK_REPLY(cc, reply);
     CHECK_REPLY_TYPE(reply, VALKEY_REPLY_INTEGER);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     valkeyClusterGetReply(cc, (void *)&reply);
     assert(reply == NULL);
@@ -246,21 +246,21 @@ void test_pipeline_transaction(valkeyClusterContext *cc) {
     {
         valkeyClusterGetReply(cc, (void *)&reply); // MULTI
         CHECK_REPLY_OK(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
         valkeyClusterGetReply(cc, (void *)&reply); // SET
         CHECK_REPLY_QUEUED(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
         valkeyClusterGetReply(cc, (void *)&reply); // INCR
         CHECK_REPLY_QUEUED(cc, reply);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
 
         valkeyClusterGetReply(cc, (void *)&reply); // EXEC
         CHECK_REPLY_ARRAY(cc, reply, 2);
         CHECK_REPLY_OK(cc, reply->element[0]);
         CHECK_REPLY_INT(cc, reply->element[1], 200);
-        freeReplyObject(reply);
+        valkeyFreeReplyObject(reply);
     }
 }
 

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -41,11 +41,11 @@ void load_valkey_version(valkeyClusterContext *cc) {
         goto abort;
     server_version_minor = strtol(eptr + 1, NULL, 10);
 
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     return;
 
 abort:
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     fprintf(stderr, "Error: Cannot get Valkey version, aborting..\n");
     exit(1);
 }

--- a/tests/ut_slotmap_update.c
+++ b/tests/ut_slotmap_update.c
@@ -156,7 +156,7 @@ void test_parse_cluster_nodes(bool parse_replicas) {
         "824fe116063bc5fcf9f4ffd895bc17aee7731ac3 127.0.0.1:30006@31006,hostname6 slave 292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 0 1426238317741 6 connected\n"
         "e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,hostname1 myself,master - 0 0 1 connected 0-5460\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 3); /* 3 masters */
@@ -241,7 +241,7 @@ void test_parse_cluster_nodes_during_failover(void) {
         "8675cd30fdd4efa088634e50fbd5c0675238a35e 10.10.10.124:7000@17000 slave 22de56650b3714c1c42fc0d120f80c66c24d8795 0 1625255655360 3 connected\n"
         "4394d8eb03de1f524b56cb385f0eb9052ce65283 10.10.10.121:7000@17000 myself,master - 0 1625255653000 1 connected 0-5460\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 4); /* 4 masters */
@@ -302,7 +302,7 @@ void test_parse_cluster_nodes_with_noaddr(void) {
         "e839a12fbed631de867016f636d773e644562e72 127.0.0.0:6379@16379 myself,master - 0 1658755601000 1 connected 0-5460\n"
         "87f785c4a51f58c06e4be55de8c112210a811db9 127.0.0.2:6379@16379 master - 0 1658755602418 3 connected 10923-16383\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 2); /* Only 2 primaries since `noaddr` nodes are skipped. */
@@ -334,7 +334,7 @@ void test_parse_cluster_nodes_with_empty_ip(void) {
         "e839a12fbed631de867016f636d773e644562e72 127.0.0.1:6379@16379 master - 0 1658755601000 1 connected 0-5460\n"
         "87f785c4a51f58c06e4be55de8c112210a811db9 127.0.0.2:6379@16379 master - 0 1658755602418 3 connected 10923-16383\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 3);
@@ -369,7 +369,7 @@ void test_parse_cluster_nodes_with_special_slot_entries(void) {
     valkeyReply *reply = create_cluster_nodes_reply(
         "4394d8eb03de1f524b56cb385f0eb9052ce65283 10.10.10.121:7000@17000 myself,master - 0 1625255653000 1 connected 0 2-5460 [0->-e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca] [1-<-292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f]\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 1); /* 1 master */
@@ -415,7 +415,7 @@ void test_parse_cluster_nodes_with_multiple_replicas(void) {
         "67ed2db8d677e59ec4a4cefb06858cf2a1a89fa1 127.0.0.1:30002@31002,hostname2 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238316232 2 connected\n"
         "292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 127.0.0.1:30003@31003,hostname3 slave e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 0 1426238318243 3 connected\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Verify master. */
     assert(nodes);
@@ -473,7 +473,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     reply = create_cluster_nodes_reply(
         "e839a12fbed631de867016f636d773e644562e72 127.0.0.0:30001@31001 myself,master - 0 1658755601000 1 \n");
     nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     assert(nodes == NULL);
     assert(cc->err == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
@@ -482,7 +482,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     reply = create_cluster_nodes_reply(
         "e839a12fbed631de867016f636d773e644562e72 127.0.0.0@31001 myself,master - 0 1658755601000 1 connected 0-5460\n");
     nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     assert(nodes == NULL);
     assert(cc->err == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
@@ -491,7 +491,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     reply = create_cluster_nodes_reply(
         "e839a12fbed631de867016f636d773e644562e72 127.0.0.0 myself,master - 0 1658755601000 1 connected 0-5460\n");
     nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     assert(nodes == NULL);
     assert(cc->err == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
@@ -500,7 +500,7 @@ void test_parse_cluster_nodes_with_parse_error(void) {
     reply = create_cluster_nodes_reply(
         "e839a12fbed631de867016f636d773e644562e72 127.0.0.0:66000@67000 myself,master - 0 1658755601000 1 connected 0-5460\n");
     nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
     assert(nodes == NULL);
     assert(cc->err == VALKEY_ERR_OTHER);
     valkeyClusterClearError(cc);
@@ -522,7 +522,7 @@ void test_parse_cluster_nodes_with_legacy_format(void) {
         "e839a12fbed631de867016f636d773e644562e72 127.0.0.0:6379 myself,master - 0 1658755601000 1 connected 0-5460\n"
         "752d150249c157c7cb312b6b056517bbbecb42d2 :0 master,noaddr - 1658754833817 1658754833000 3 disconnected 5461-10922\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 1); /* Only 1 primary since `noaddr` nodes are skipped. */
@@ -549,7 +549,7 @@ void test_parse_cluster_nodes_with_resp3(void) {
         "292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f 127.0.0.1:30003@31003,hostname3 master - 0 1426238318243 3 connected 10923-16383\n"
         "e7d1eecce10fd6bb5eb35b9f99a514335d9ba9ca 127.0.0.1:30001@31001,hostname1 myself,master - 0 0 1 connected 0-5460\n");
     dict *nodes = parse_cluster_nodes(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 3); /* 3 primaries */
@@ -593,7 +593,7 @@ void test_parse_cluster_slots(bool parse_replicas) {
         "                ['127.0.0.1', 30006, '824fe116063bc5fcf9f4ffd895bc17aee7731ac3', ['hostname', 'localhost']]]]");
 
     dict *nodes = parse_cluster_slots(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 3); /* 3 primaries */
@@ -674,7 +674,7 @@ void test_parse_cluster_slots_with_empty_ip(void) {
         " [10923, 16383, ['127.0.0.2', 6379, '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f']]]");
 
     dict *nodes = parse_cluster_slots(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 3);
@@ -710,7 +710,7 @@ void test_parse_cluster_slots_with_null_ip(void) {
         " [10923, 16383, ['127.0.0.2', 6379, '292f8b365bb7edb5e285caf0b7e6ddc7265d2f4f']]]");
 
     dict *nodes = parse_cluster_slots(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     assert(nodes);
     assert(dictSize(nodes) == 3);
@@ -751,7 +751,7 @@ void test_parse_cluster_slots_with_multiple_replicas(void) {
         "            ['127.0.0.1', 30003, '824fe116063bc5fcf9f4ffd895bc17aee7731ac3']]]");
 
     dict *nodes = parse_cluster_slots(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Verify primary. */
     assert(nodes);
@@ -811,7 +811,7 @@ void test_parse_cluster_slots_with_noncontiguous_slots(void) {
         "           ['127.0.0.1', 30004, '07c37dfeb235213a872192d90877d0cd55635b91']]]");
 
     dict *nodes = parse_cluster_slots(cc, c, reply);
-    freeReplyObject(reply);
+    valkeyFreeReplyObject(reply);
 
     /* Verify primary. */
     assert(nodes);


### PR DESCRIPTION
The old name was inherited from hiredis and conflicts when both libraries are linked into the same binary.
Rename to follow the valkey prefix convention used by the rest of the API.
    
This is a breaking API change.

Fixes #288 