### PR TITLE
Try all addresses from DNS before failing to connect

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -43,6 +43,8 @@ valkeyContext *valkeyConnectWithOptions(valkeyOptions *opt);
 
 When connecting to a server, libvalkey will return `NULL` in the event that we can't allocate the context, and set the `err` member if we can connect but there are issues. So when connecting it's simple to handle error states.
 
+When a hostname resolves to multiple addresses, libvalkey will try each address in order until one succeeds or all have failed. Note that the `connect_timeout` applies per address, so the total connection time may be up to N × timeout when multiple addresses are unreachable.
+
 ```c
 valkeyContext *ctx = valkeyConnect("localhost", 6379);
 if (ctx == NULL || ctx->err) {

--- a/src/net.c
+++ b/src/net.c
@@ -561,6 +561,7 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
 
         c->flags |= VALKEY_CONNECTED;
         rv = VALKEY_OK;
+        valkeyClearError(c);
         goto end;
     }
     if (p == NULL) {

--- a/src/net.c
+++ b/src/net.c
@@ -534,23 +534,21 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
 
         if (connect(s, p->ai_addr, p->ai_addrlen) == -1) {
             if (errno == EINPROGRESS) {
-                if (blocking && valkeyContextWaitReady(c, timeout_msec) != VALKEY_OK)
-                    goto error;
+                if (blocking && valkeyContextWaitReady(c, timeout_msec) != VALKEY_OK) {
+                    valkeyNetClose(c);
+                    continue;
+                }
                 /* Non-blocking: EINPROGRESS is expected, continue to success. */
-            } else if (errno == EHOSTUNREACH) {
-                valkeyNetClose(c);
-                continue;
             } else if (errno == EADDRNOTAVAIL && reuseaddr) {
                 valkeyNetClose(c);
                 if (++reuses >= VALKEY_CONNECT_RETRIES) {
-                    goto error;
+                    continue;
                 } else {
                     goto addrretry;
                 }
             } else {
-                valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
                 valkeyNetClose(c);
-                goto error;
+                continue;
             }
         }
         /* TCP_NODELAY is set here for blocking connections only. For non-blocking,

--- a/src/net.c
+++ b/src/net.c
@@ -486,6 +486,7 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
             continue;
 
         c->fd = s;
+        /* Use non-blocking connect to be able to enforce connect timeout. */
         if (valkeySetBlocking(c, 0) != VALKEY_OK)
             goto error;
         if (c->tcp.source_addr) {
@@ -532,32 +533,31 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
         c->addrlen = p->ai_addrlen;
 
         if (connect(s, p->ai_addr, p->ai_addrlen) == -1) {
-            if (errno == EHOSTUNREACH) {
+            if (errno == EINPROGRESS) {
+                if (blocking && valkeyContextWaitReady(c, timeout_msec) != VALKEY_OK)
+                    goto error;
+                /* Non-blocking: EINPROGRESS is expected, continue to success. */
+            } else if (errno == EHOSTUNREACH) {
                 valkeyNetClose(c);
                 continue;
-            } else if (errno == EINPROGRESS) {
-                if (blocking) {
-                    goto wait_for_ready;
-                }
-                /* This is ok.
-                 * Note that even when it's in blocking mode, we unset blocking
-                 * for `connect()`
-                 */
             } else if (errno == EADDRNOTAVAIL && reuseaddr) {
+                valkeyNetClose(c);
                 if (++reuses >= VALKEY_CONNECT_RETRIES) {
                     goto error;
                 } else {
-                    valkeyNetClose(c);
                     goto addrretry;
                 }
             } else {
-            wait_for_ready:
-                if (valkeyContextWaitReady(c, timeout_msec) != VALKEY_OK)
-                    goto error;
-                if (valkeySetTcpNoDelay(c) != VALKEY_OK)
-                    goto error;
+                valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
+                valkeyNetClose(c);
+                goto error;
             }
         }
+        /* TCP_NODELAY is set here for blocking connections only. For non-blocking,
+         * it's deferred to valkeyAsyncHandleConnect() after connect completes,
+         * since some systems reject setsockopt on in-progress sockets. */
+        if (blocking && valkeySetTcpNoDelay(c) != VALKEY_OK)
+            goto error;
         if (blocking && valkeySetBlocking(c, 1) != VALKEY_OK)
             goto error;
 
@@ -566,9 +566,7 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
         goto end;
     }
     if (p == NULL) {
-        char buf[128];
-        snprintf(buf, sizeof(buf), "Can't create socket: %s", strerror(errno));
-        valkeySetError(c, VALKEY_ERR_OTHER, buf);
+        valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
         goto error;
     }
 

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -709,6 +709,11 @@ void valkeySetError(valkeyContext *c, int type, const char *str) {
     }
 }
 
+void valkeyClearError(valkeyContext *c) {
+    c->err = 0;
+    memset(c->errstr, '\0', strlen(c->errstr));
+}
+
 valkeyReader *valkeyReaderCreate(void) {
     return valkeyReaderCreateWithFunctions(&defaultFunctions);
 }

--- a/src/valkey_private.h
+++ b/src/valkey_private.h
@@ -42,6 +42,7 @@
 #include <string.h>
 
 LIBVALKEY_API void valkeySetError(valkeyContext *c, int type, const char *str);
+void valkeyClearError(valkeyContext *c);
 
 /* Helper function. Convert struct timeval to millisecond. */
 static inline int valkeyContextTimeoutMsec(const struct timeval *timeout, long *result) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,13 @@ target_include_directories(ut_slotmap_update PRIVATE "${PROJECT_SOURCE_DIR}/src"
 target_link_libraries(ut_slotmap_update valkey_unittest)
 add_test(NAME ut_slotmap_update COMMAND "$<TARGET_FILE:ut_slotmap_update>")
 
+if(NOT WIN32 AND NOT CYGWIN)
+  add_executable(ut_connect_fallback ut_connect_fallback.c)
+  target_compile_options(ut_connect_fallback PRIVATE -Wno-pedantic)
+  target_link_libraries(ut_connect_fallback valkey_unittest dl)
+  add_test(NAME ut_connect_fallback COMMAND "$<TARGET_FILE:ut_connect_fallback>")
+endif()
+
 # Cluster tests
 add_executable(ct_commands ct_commands.c test_utils.c)
 target_link_libraries(ct_commands valkey ${TLS_LIBRARY})

--- a/tests/ut_connect_fallback.c
+++ b/tests/ut_connect_fallback.c
@@ -1,0 +1,125 @@
+/*
+ * Unit test for TCP connect fallback behavior.
+ *
+ * Verifies that valkeyContextConnectTcp iterates through all addresses in the
+ * DNS response when earlier ones fail. We override getaddrinfo() to return three
+ * entries for 127.0.0.1 and override connect() to fail with ECONNREFUSED on the
+ * first two. The third entry points to a real listening socket and should
+ * succeed.
+ */
+
+#define _GNU_SOURCE
+#include "fmacros.h"
+
+#include "sockcompat.h"
+#include "valkey.h"
+
+#include <assert.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+static int port_listen;
+static struct addrinfo *make_entry(int port, struct addrinfo *next);
+
+/* --- Overridden system calls --- */
+
+/*
+ * Override getaddrinfo(3) to return a crafted address list instead of doing
+ * real DNS resolution. Linked before libc due to static library ordering.
+ */
+int getaddrinfo(const char *node, const char *service,
+                const struct addrinfo *hints, struct addrinfo **res) {
+    (void)node;
+    (void)service;
+    (void)hints;
+    struct addrinfo *third = make_entry(port_listen, NULL);
+    struct addrinfo *second = make_entry(10001, third);
+    struct addrinfo *first = make_entry(10000, second);
+    *res = first;
+    return 0;
+}
+
+/* Override freeaddrinfo(3) to match the crafted getaddrinfo above. */
+void freeaddrinfo(struct addrinfo *res) {
+    while (res) {
+        struct addrinfo *next = res->ai_next;
+        free(res->ai_addr);
+        free(res);
+        res = next;
+    }
+}
+
+/*
+ * Override connect(2) to simulate ECONNREFUSED for the fake addresses.
+ * Falls through to the real connect via dlsym(RTLD_NEXT) for other addresses.
+ */
+int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
+    static int (*real_connect)(int, const struct sockaddr *, socklen_t) = NULL;
+    if (!real_connect)
+        real_connect = dlsym(RTLD_NEXT, "connect");
+
+    assert(addr->sa_family == AF_INET);
+    const struct sockaddr_in *sa = (const struct sockaddr_in *)addr;
+    int port = ntohs(sa->sin_port);
+    if (port == 10000 || port == 10001) {
+        errno = ECONNREFUSED;
+        return -1;
+    }
+    return real_connect(sockfd, addr, addrlen);
+}
+
+/* --- Helpers --- */
+
+/* Build a single addrinfo entry for 127.0.0.1 on the given port. */
+static struct addrinfo *make_entry(int port, struct addrinfo *next) {
+    struct addrinfo *ai = calloc(1, sizeof(*ai));
+    struct sockaddr_in *sa = calloc(1, sizeof(*sa));
+    assert(ai && sa);
+    sa->sin_family = AF_INET;
+    sa->sin_port = htons(port);
+    sa->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    ai->ai_family = AF_INET;
+    ai->ai_socktype = SOCK_STREAM;
+    ai->ai_addrlen = sizeof(*sa);
+    ai->ai_addr = (struct sockaddr *)sa;
+    ai->ai_next = next;
+    return ai;
+}
+
+/* Create a TCP listener on 127.0.0.1 with an OS-assigned port. */
+static int create_listener(int *out_port) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(fd >= 0);
+    struct sockaddr_in addr = {.sin_family = AF_INET,
+                               .sin_addr.s_addr = htonl(INADDR_LOOPBACK)};
+    assert(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+    assert(listen(fd, 1) == 0);
+    socklen_t len = sizeof(addr);
+    assert(getsockname(fd, (struct sockaddr *)&addr, &len) == 0);
+    *out_port = ntohs(addr.sin_port);
+    return fd;
+}
+
+int main(void) {
+    int listen_fd = create_listener(&port_listen);
+
+    printf("Test: connect falls back to next address after ECONNREFUSED\n");
+
+    /* Arguments are ignored by our getaddrinfo override. */
+    valkeyContext *c = valkeyConnect("localhost", 0);
+    assert(c != NULL);
+    if (c->err) {
+        fprintf(stderr, "FAIL: %s\n", c->errstr);
+        valkeyFree(c);
+        close(listen_fd);
+        return 1;
+    }
+
+    printf("PASS\n");
+    valkeyFree(c);
+    close(listen_fd);
+    return 0;
+}

--- a/tests/ut_connect_fallback.c
+++ b/tests/ut_connect_fallback.c
@@ -22,6 +22,9 @@
 #include <unistd.h>
 
 static int port_listen;
+
+#define PORT_ECONNREFUSED  10000 /* Simulates failed non-blocking connect */
+#define PORT_EHOSTUNREACH 10001 /* Simulates immediate routing failure */
 static struct addrinfo *make_entry(int port, struct addrinfo *next);
 
 /* --- Overridden system calls --- */
@@ -36,8 +39,8 @@ int getaddrinfo(const char *node, const char *service,
     (void)service;
     (void)hints;
     struct addrinfo *third = make_entry(port_listen, NULL);
-    struct addrinfo *second = make_entry(10001, third);
-    struct addrinfo *first = make_entry(10000, second);
+    struct addrinfo *second = make_entry(PORT_EHOSTUNREACH, third);
+    struct addrinfo *first = make_entry(PORT_ECONNREFUSED, second);
     *res = first;
     return 0;
 }
@@ -53,10 +56,13 @@ void freeaddrinfo(struct addrinfo *res) {
 }
 
 /*
- * Override connect(2) to simulate ECONNREFUSED for the fake addresses.
+ * Override connect(2) to simulate connect failures for the fake addresses.
+ * Port 10000 returns EINPROGRESS then ECONNREFUSED (failed non-blocking connect).
+ * Port 10001 returns EHOSTUNREACH (immediate routing failure).
  * Falls through to the real connect via dlsym(RTLD_NEXT) for other addresses.
  */
 int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
+    static int refused_attempts = 0;
     static int (*real_connect)(int, const struct sockaddr *, socklen_t) = NULL;
     if (!real_connect)
         real_connect = dlsym(RTLD_NEXT, "connect");
@@ -64,8 +70,12 @@ int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen) {
     assert(addr->sa_family == AF_INET);
     const struct sockaddr_in *sa = (const struct sockaddr_in *)addr;
     int port = ntohs(sa->sin_port);
-    if (port == 10000 || port == 10001) {
-        errno = ECONNREFUSED;
+    if (port == PORT_ECONNREFUSED) {
+        errno = (refused_attempts++ == 0) ? EINPROGRESS : ECONNREFUSED;
+        return -1;
+    }
+    if (port == PORT_EHOSTUNREACH) {
+        errno = EHOSTUNREACH;
         return -1;
     }
     return real_connect(sockfd, addr, addrlen);
@@ -117,6 +127,8 @@ int main(void) {
         close(listen_fd);
         return 1;
     }
+    assert(c->err == 0);
+    assert(c->errstr[0] == '\0');
 
     printf("PASS\n");
     valkeyFree(c);

--- a/tests/ut_connect_fallback.c
+++ b/tests/ut_connect_fallback.c
@@ -23,7 +23,7 @@
 
 static int port_listen;
 
-#define PORT_ECONNREFUSED  10000 /* Simulates failed non-blocking connect */
+#define PORT_ECONNREFUSED 10000 /* Simulates failed non-blocking connect */
 #define PORT_EHOSTUNREACH 10001 /* Simulates immediate routing failure */
 static struct addrinfo *make_entry(int port, struct addrinfo *next);
 


### PR DESCRIPTION
When a hostname resolves to multiple addresses, libvalkey now iterates through all of them before giving up.
Previously only `EHOSTUNREACH` would try the next address; all other connect errors failed immediately.

The connect_timeout applies per address, not to the overall attempt.
With N addresses that all time out, the total wait is up to N * timeout.

The first commit refactors the connect error handling to prepare for the change:
- Removes the confusing `wait_for_ready` goto label
- Fixes `TCP_NODELAY` not being set on immediate connect success
- Reorders `errno` checks to put `EINPROGRESS` first
- Makes each error branch self-contained

The second commit adds the fallback behavior and a unit test that overrides `getaddrinfo` and `connect` to verify that the library falls back to a working address after earlier ones fail with `ECONNREFUSED`.