### PR TITLE
Remove support for external dict while still supporting external sds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,19 +46,16 @@ set(valkey_sources
     src/command.c
     src/conn.c
     src/crc16.c
+    src/dict.c
     src/net.c
     src/read.c
     src/sockcompat.c
     src/valkey.c
     src/vkutil.c)
 
-# Allow the libvalkey provided sds and dict types to be replaced by
+# Allow the libvalkey provided sds type to be replaced by
 # compatible implementations (like Valkey's).
 # A replaced type is not included in a built archive or shared library.
-if(NOT DICT_INCLUDE_DIR)
-  set(valkey_sources ${valkey_sources} src/dict.c)
-  set(DICT_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
-endif()
 if(NOT SDS_INCLUDE_DIR)
   set(valkey_sources ${valkey_sources} src/sds.c)
   set(SDS_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -107,7 +104,6 @@ TARGET_INCLUDE_DIRECTORIES(valkey
         $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/valkey>
     PRIVATE
-        $<BUILD_INTERFACE:${DICT_INCLUDE_DIR}>
         $<BUILD_INTERFACE:${SDS_INCLUDE_DIR}>
 )
 
@@ -212,7 +208,6 @@ IF(ENABLE_TLS)
         PRIVATE
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/valkey>
-            $<BUILD_INTERFACE:${DICT_INCLUDE_DIR}>
             $<BUILD_INTERFACE:${SDS_INCLUDE_DIR}>
     )
 
@@ -289,7 +284,6 @@ if(ENABLE_RDMA)
         PRIVATE
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/valkey>
-            $<BUILD_INTERFACE:${DICT_INCLUDE_DIR}>
             $<BUILD_INTERFACE:${SDS_INCLUDE_DIR}>
     )
 

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,8 @@ HEADERS = $(filter-out $(INCLUDE_DIR)/tls.h $(INCLUDE_DIR)/rdma.h, $(wildcard $(
 # compatible implementations (like Valkey's).
 # A replaced type is not included in a built archive or shared library.
 SDS_INCLUDE_DIR ?= $(SRC_DIR)
-DICT_INCLUDE_DIR ?= $(SRC_DIR)
 ifneq ($(SDS_INCLUDE_DIR),$(SRC_DIR))
   SOURCES := $(filter-out $(SRC_DIR)/sds.c, $(SOURCES))
-endif
-ifneq ($(DICT_INCLUDE_DIR),$(SRC_DIR))
-  SOURCES := $(filter-out $(SRC_DIR)/dict.c, $(SOURCES))
 endif
 
 OBJS = $(patsubst $(SRC_DIR)/%.c,$(OBJ_DIR)/%.o,$(SOURCES))
@@ -268,10 +264,10 @@ $(RDMA_STLIBNAME): $(RDMA_OBJS)
 	$(STLIB_MAKE_CMD) $(RDMA_STLIBNAME) $(RDMA_OBJS)
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.c | $(OBJ_DIR)
-	$(CC) -std=c99 -pedantic $(REAL_CFLAGS) -I$(INCLUDE_DIR) -I$(SDS_INCLUDE_DIR) -I$(DICT_INCLUDE_DIR) -MMD -MP -c $< -o $@
+	$(CC) -std=c99 -pedantic $(REAL_CFLAGS) -I$(INCLUDE_DIR) -I$(SDS_INCLUDE_DIR) -MMD -MP -c $< -o $@
 
 $(OBJ_DIR)/%.o: $(TEST_DIR)/%.c | $(OBJ_DIR)
-	$(CC) -std=c99 -pedantic $(REAL_CFLAGS) -I$(INCLUDE_DIR) -I$(SDS_INCLUDE_DIR) -I$(DICT_INCLUDE_DIR) -I$(SRC_DIR) -MMD -MP -c $< -o $@
+	$(CC) -std=c99 -pedantic $(REAL_CFLAGS) -I$(INCLUDE_DIR) -I$(SDS_INCLUDE_DIR) -I$(SRC_DIR) -MMD -MP -c $< -o $@
 
 $(TEST_DIR)/%: $(OBJ_DIR)/%.o $(STLIBNAME) $(TLS_STLIB)
 	$(CC) -o $@ $< $(RDMA_STLIB) $(STLIBNAME) $(TLS_STLIB) $(REAL_LDFLAGS) $(TEST_LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TEST_BINS = $(patsubst $(TEST_DIR)/%.c,$(TEST_DIR)/%,$(TEST_SRCS))
 SOURCES = $(filter-out $(SRC_DIR)/tls.c $(SRC_DIR)/rdma.c, $(wildcard $(SRC_DIR)/*.c))
 HEADERS = $(filter-out $(INCLUDE_DIR)/tls.h $(INCLUDE_DIR)/rdma.h, $(wildcard $(INCLUDE_DIR)/*.h))
 
-# Allow the libvalkey provided sds and dict types to be replaced by
+# Allow the libvalkey provided sds type to be replaced by
 # compatible implementations (like Valkey's).
 # A replaced type is not included in a built archive or shared library.
 SDS_INCLUDE_DIR ?= $(SRC_DIR)

--- a/src/async.c
+++ b/src/async.c
@@ -44,10 +44,10 @@
 
 #include "async.h"
 #include "async_private.h"
+#include "dict.h"
 #include "net.h"
 #include "valkey_private.h"
 #include "vkutil.h"
-#include "dict.h"
 
 #include <sds.h>
 

--- a/src/async.c
+++ b/src/async.c
@@ -47,8 +47,8 @@
 #include "net.h"
 #include "valkey_private.h"
 #include "vkutil.h"
+#include "dict.h"
 
-#include <dict.h>
 #include <sds.h>
 
 #include <assert.h>

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -39,8 +39,8 @@
 #include "alloc.h"
 #include "command.h"
 #include "vkutil.h"
+#include "dict.h"
 
-#include <dict.h>
 #include <sds.h>
 
 #include <assert.h>

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -38,8 +38,8 @@
 #include "adlist.h"
 #include "alloc.h"
 #include "command.h"
-#include "vkutil.h"
 #include "dict.h"
+#include "vkutil.h"
 
 #include <sds.h>
 


### PR DESCRIPTION
These two appeared independent, but because they both set include paths, they couldn't be used independently. Instead of fixing that, we just remove the support for using external dict.

The reason is that valkey (where libvalkey is vendored and uses external components from valkey's counterparts) has changed the dict implementation so that the API is no longer compatible, but there are no symbol collisions either, so it's fine for libvalkey to use its own dict.

Extracted from
https://github.com/valkey-io/valkey/commit/fb655dbf5cfaf254e0b8bb6617f1f734dbebc07d