### PR TITLE
Refactor error handling to use valkeySetErrorFromErrno and valkeyClearError

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -100,17 +100,6 @@ static ssize_t valkeyNetWrite(valkeyContext *c) {
     return nwritten;
 }
 
-static void valkeySetErrorFromErrno(valkeyContext *c, int type, const char *prefix) {
-    int errorno = errno; /* snprintf() may change errno */
-    char buf[128] = {0};
-    size_t len = 0;
-
-    if (prefix != NULL)
-        len = snprintf(buf, sizeof(buf), "%s: ", prefix);
-    strerror_r(errorno, (char *)(buf + len), sizeof(buf) - len);
-    valkeySetError(c, type, buf);
-}
-
 static int valkeySetReuseAddr(valkeyContext *c) {
     int on = 1;
     if (setsockopt(c->fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {

--- a/src/net.c
+++ b/src/net.c
@@ -505,9 +505,7 @@ int valkeyContextConnectTcp(valkeyContext *c, const valkeyOptions *options) {
             }
             freeaddrinfo(bservinfo);
             if (!bound) {
-                char buf[128];
-                snprintf(buf, sizeof(buf), "Can't bind socket: %s", strerror(errno));
-                valkeySetError(c, VALKEY_ERR_OTHER, buf);
+                valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, "Can't bind socket");
                 goto error;
             }
         }

--- a/src/net.c
+++ b/src/net.c
@@ -72,7 +72,7 @@ static ssize_t valkeyNetRead(valkeyContext *c, char *buf, size_t bufcap) {
             valkeySetError(c, VALKEY_ERR_TIMEOUT, "recv timeout");
             return -1;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, strerror(errno));
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     } else if (nread == 0) {
@@ -92,7 +92,7 @@ static ssize_t valkeyNetWrite(valkeyContext *c) {
             /* Try again */
             return 0;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, strerror(errno));
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     }
@@ -169,7 +169,7 @@ int valkeyKeepAlive(valkeyContext *c, int interval) {
 
 #ifndef _WIN32
     if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) == -1) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 
@@ -177,13 +177,13 @@ int valkeyKeepAlive(valkeyContext *c, int interval) {
 
 #if defined(__APPLE__) && defined(__MACH__)
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPALIVE, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 #else
 #if defined(__GLIBC__) && !defined(__FreeBSD_kernel__)
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 
@@ -191,13 +191,13 @@ int valkeyKeepAlive(valkeyContext *c, int interval) {
     if (val == 0)
         val = 1;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 
     val = 3;
     if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &val, sizeof(val)) < 0) {
-        valkeySetError(c, VALKEY_ERR_OTHER, strerror(errno));
+        valkeySetErrorFromErrno(c, VALKEY_ERR_OTHER, NULL);
         return VALKEY_ERR;
     }
 #endif

--- a/src/tls.c
+++ b/src/tls.c
@@ -508,12 +508,11 @@ static ssize_t valkeyTLSRead(valkeyContext *c, char *buf, size_t bufcap) {
              */
             if (errno == EINTR) {
                 return 0;
+            } else if (errno == EAGAIN) {
+                valkeySetError(c, VALKEY_ERR_IO, "Resource temporarily unavailable");
+                return -1;
             } else {
-                const char *msg = NULL;
-                if (errno == EAGAIN) {
-                    msg = "Resource temporarily unavailable";
-                }
-                valkeySetError(c, VALKEY_ERR_IO, msg);
+                valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
                 return -1;
             }
         }
@@ -524,7 +523,7 @@ static ssize_t valkeyTLSRead(valkeyContext *c, char *buf, size_t bufcap) {
         if (maybeCheckWant(rssl, err)) {
             return 0;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, NULL);
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     }
@@ -545,7 +544,7 @@ static ssize_t valkeyTLSWrite(valkeyContext *c) {
         if ((c->flags & VALKEY_BLOCK) == 0 && maybeCheckWant(rssl, err)) {
             return 0;
         } else {
-            valkeySetError(c, VALKEY_ERR_IO, NULL);
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             return -1;
         }
     }

--- a/src/tls.c
+++ b/src/tls.c
@@ -392,15 +392,15 @@ static int valkeyTLSConnect(valkeyContext *c, SSL *ssl) {
     }
 
     if (c->err == 0) {
-        char err[512];
         if (rv == SSL_ERROR_SYSCALL)
-            snprintf(err, sizeof(err) - 1, "SSL_connect failed: %s", strerror(errno));
+            valkeySetErrorFromErrno(c, VALKEY_ERR_IO, "SSL_connect failed");
         else {
             unsigned long e = ERR_peek_last_error();
-            snprintf(err, sizeof(err) - 1, "SSL_connect failed: %s",
+            char err[512];
+            snprintf(err, sizeof(err), "SSL_connect failed: %s",
                      ERR_reason_error_string(e));
+            valkeySetError(c, VALKEY_ERR_IO, err);
         }
-        valkeySetError(c, VALKEY_ERR_IO, err);
     }
 
     vk_free(rssl);

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -697,16 +697,21 @@ void valkeySetError(valkeyContext *c, int type, const char *str) {
     size_t len;
 
     c->err = type;
-    if (str != NULL) {
-        len = strlen(str);
-        len = len < (sizeof(c->errstr) - 1) ? len : (sizeof(c->errstr) - 1);
-        memcpy(c->errstr, str, len);
-        c->errstr[len] = '\0';
-    } else {
-        /* Only VALKEY_ERR_IO may lack a description! */
-        assert(type == VALKEY_ERR_IO);
-        strerror_r(errno, c->errstr, sizeof(c->errstr));
-    }
+    len = strlen(str);
+    len = len < (sizeof(c->errstr) - 1) ? len : (sizeof(c->errstr) - 1);
+    memcpy(c->errstr, str, len);
+    c->errstr[len] = '\0';
+}
+
+void valkeySetErrorFromErrno(valkeyContext *c, int type, const char *prefix) {
+    int errorno = errno; /* snprintf() may change errno */
+    char buf[128] = {0};
+    size_t len = 0;
+
+    if (prefix != NULL)
+        len = snprintf(buf, sizeof(buf), "%s: ", prefix);
+    strerror_r(errorno, (char *)(buf + len), sizeof(buf) - len);
+    valkeySetError(c, type, buf);
 }
 
 void valkeyClearError(valkeyContext *c) {

--- a/src/valkey.c
+++ b/src/valkey.c
@@ -779,8 +779,7 @@ valkeyFD valkeyFreeKeepFd(valkeyContext *c) {
 int valkeyReconnect(valkeyContext *c) {
     valkeyOptions options = {.connect_timeout = c->connect_timeout};
 
-    c->err = 0;
-    memset(c->errstr, '\0', strlen(c->errstr));
+    valkeyClearError(c);
 
     assert(c->funcs);
     if (c->funcs && c->funcs->close)

--- a/src/valkey_private.h
+++ b/src/valkey_private.h
@@ -42,6 +42,7 @@
 #include <string.h>
 
 LIBVALKEY_API void valkeySetError(valkeyContext *c, int type, const char *str);
+LIBVALKEY_API void valkeySetErrorFromErrno(valkeyContext *c, int type, const char *prefix);
 void valkeyClearError(valkeyContext *c);
 
 /* Helper function. Convert struct timeval to millisecond. */


### PR DESCRIPTION
Clean up error handling across the codebase:

- Promote `valkeySetErrorFromErrno()` from a static function in `net.c` to an exported function in `valkey.c`, making it available to `tls.c`.
- Remove the NULL special case from `valkeySetError()` since all callers now use `valkeySetErrorFromErrno()` for `errno`-based errors.
- Replace thread-unsafe `strerror(errno)` calls with `valkeySetErrorFromErrno()` which uses `strerror_r()` internally.
- Use `valkeyClearError()` in `valkeyReconnect()`.
