### PR TITLE
Fix potential heap-buffer-overflow in cluster error reply parsing

### DIFF
--- a/src/cluster.c
+++ b/src/cluster.c
@@ -212,13 +212,13 @@ static replyErrorType getReplyErrorType(valkeyReply *reply) {
 
     if (reply->type != VALKEY_REPLY_ERROR)
         return CLUSTER_NO_ERROR;
-    if (memcmp(reply->str, "MOVED", 5) == 0)
+    if (reply->len >= 5 && memcmp(reply->str, "MOVED", 5) == 0)
         return CLUSTER_ERR_MOVED;
-    if (memcmp(reply->str, "ASK", 3) == 0)
+    if (reply->len >= 3 && memcmp(reply->str, "ASK", 3) == 0)
         return CLUSTER_ERR_ASK;
-    if (memcmp(reply->str, "TRYAGAIN", 8) == 0)
+    if (reply->len >= 8 && memcmp(reply->str, "TRYAGAIN", 8) == 0)
         return CLUSTER_ERR_TRYAGAIN;
-    if (memcmp(reply->str, "CLUSTERDOWN", 11) == 0)
+    if (reply->len >= 11 && memcmp(reply->str, "CLUSTERDOWN", 11) == 0)
         return CLUSTER_ERR_CLUSTERDOWN;
     return CLUSTER_ERR_OTHER;
 }

--- a/tests/clusterclient.c
+++ b/tests/clusterclient.c
@@ -27,6 +27,8 @@
 void printReply(const valkeyReply *reply) {
     switch (reply->type) {
     case VALKEY_REPLY_ERROR:
+        printf("Error: %s\n", reply->str);
+        break;
     case VALKEY_REPLY_STATUS:
     case VALKEY_REPLY_STRING:
     case VALKEY_REPLY_VERB:

--- a/tests/clusterclient_async.c
+++ b/tests/clusterclient_async.c
@@ -64,6 +64,8 @@ void sendNextCommand(evutil_socket_t, short, void *);
 void printReply(const valkeyReply *reply) {
     switch (reply->type) {
     case VALKEY_REPLY_ERROR:
+        printf("Error: %s\n", reply->str);
+        break;
     case VALKEY_REPLY_STATUS:
     case VALKEY_REPLY_STRING:
     case VALKEY_REPLY_VERB:

--- a/tests/scripts/client-disconnect-test.sh
+++ b/tests/scripts/client-disconnect-test.sh
@@ -69,7 +69,7 @@ fi
 
 expected="Event: connect to 127.0.0.1:7401
 OK
-MOVED 12182 127.0.0.1:7402
+Error: MOVED 12182 127.0.0.1:7402
 Event: disconnect from 127.0.0.1:7401
 error: disconnecting"
 

--- a/tests/scripts/moved-redirect-test.sh
+++ b/tests/scripts/moved-redirect-test.sh
@@ -38,6 +38,10 @@ EXPECT CLOSE
 EXPECT CONNECT
 EXPECT ["GET", "foo"]
 SEND "bar"
+
+# Test 3: Handle truncated errors (no heap-buffer-overflow).
+EXPECT ["GET", "foo"]
+SEND -MO
 EXPECT CLOSE
 EOF
 server1=$!
@@ -69,6 +73,8 @@ GET foo
 GET foo
 !sleep
 GET foo
+# Test 3
+GET foo
 EOF
 clientexit=$?
 
@@ -98,6 +104,7 @@ Event: slotmap-updated
 bar
 Event: slotmap-updated
 bar
+Error: MO
 Event: free-context"
 
 echo "$expected" | diff -u - "$testname.out" || exit 99


### PR DESCRIPTION
Add length checks in getReplyErrorType() before calling memcmp to prevent reading past the end of reply->str when a server sends a short error reply.

While a conforming server always sends complete error strings like "MOVED 1234 host:port", a malicious or buggy server could send a truncated error (e.g., -MO\r\n), causing memcmp to read beyond the allocated buffer. This is undefined behavior and is flagged by AddressSanitizer.

Also update the sync test client (clusterclient.c) to print server error replies with an "Error:" prefix, distinguishing them from successful replies, and add a test case that exercises the fix.