### PR TITLE
Suppress constant-promotion warnings on Solaris Sun CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ else ifeq ($(uname_S),SunOS)
   ifeq ($(HAVE_SUN_CC),1)
     SUN_SHARED_FLAG = -G
     REAL_CFLAGS    += -mt
+    REAL_CFLAGS    += -erroff=E_CONST_PROMOTED_LONG_LONG,E_CONST_PROMOTED_UNSIGNED_LL
     ifeq ($(USE_THREADS),1)
       PTHREAD_FLAGS  += -mt
     endif


### PR DESCRIPTION
The Solaris `cc` (Oracle Developer Studio) is treating the `constant promoted to long long` warnings in the vendored `ffc.h` as errors because of `-Werror`.
```
cc -std=c99 -pedantic -O3 -fPIC -fvisibility=hidden  -DVALKEY_TEST_TLS -DVALKEY_USE_THREADS -Wall -Wextra -pedantic -Wstrict-prototypes -Wwrite-strings -Wno-missing-field-initializers -Werror -g -ggdb  -mt -errtags=yes -Iinclude/valkey -Isrc -MMD -MP -c src/read.c -o obj/read.o
  cc: Warning: Option -db passed to ld, if ld is invoked, ignored otherwise
...
  "src/ffc.h", line 891: constant promoted to long long (E_CONST_PROMOTED_LONG_LONG)
  "src/ffc.h", line 2234: constant promoted to unsigned long long (E_CONST_PROMOTED_UNSIGNED_LL)
...
  cc: acomp failed for src/read.c
 ```
It's not a real error since this behavior is defined in C99 (§6.4.4.1 paragraph 5)
On a platform where long is 32-bit, if the value doesn't fit in long or unsigned long then the compiler selects long long int. 

Lets disable the warning on this specific compiler since its in vendored code.