### PR TITLE
Replace strncpy with length-validated memcpy for Unix socket path

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -572,9 +572,15 @@ static int valkeyContextConnectUnix(valkeyContext *c, const valkeyOptions *optio
 #ifndef _WIN32
     const struct timeval *timeout = options->connect_timeout;
     const char *path = options->endpoint.unix_socket;
+    size_t pathlen = strlen(path);
     int blocking = (c->flags & VALKEY_BLOCK);
     struct sockaddr_un *sa;
     long timeout_msec = -1;
+
+    if (pathlen >= sizeof(sa->sun_path)) {
+        valkeySetError(c, VALKEY_ERR_OTHER, "Unix socket path too long");
+        return VALKEY_ERR;
+    }
 
     if (valkeyCreateSocket(c, AF_UNIX) < 0)
         return VALKEY_ERR;
@@ -605,13 +611,13 @@ static int valkeyContextConnectUnix(valkeyContext *c, const valkeyOptions *optio
     if (c->saddr)
         vk_free(c->saddr);
 
-    sa = (struct sockaddr_un *)(c->saddr = vk_malloc(sizeof(struct sockaddr_un)));
+    sa = (struct sockaddr_un *)(c->saddr = vk_calloc(1, sizeof(struct sockaddr_un)));
     if (sa == NULL)
         goto oom;
 
     c->addrlen = sizeof(struct sockaddr_un);
     sa->sun_family = AF_UNIX;
-    strncpy(sa->sun_path, path, sizeof(sa->sun_path) - 1);
+    memcpy(sa->sun_path, path, pathlen);
     if (connect(c->fd, (struct sockaddr *)sa, sizeof(*sa)) == -1) {
         if (errno == EINPROGRESS && !blocking) {
             /* This is ok. */

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -1104,6 +1104,17 @@ static void test_blocking_connection_errors(void) {
     c = valkeyConnectUnix((char *)"/tmp/nonexistent.sock");
     test_cond(c->err == VALKEY_ERR_IO); /* Don't care about the message... */
     valkeyFree(c);
+
+    test("Returns error when the unix_sock socket path is too long: ");
+    {
+        char long_path[256];
+        memset(long_path, 'a', sizeof(long_path) - 1);
+        long_path[sizeof(long_path) - 1] = '\0';
+        c = valkeyConnectUnix(long_path);
+        test_cond(c->err == VALKEY_ERR_OTHER &&
+                  strcmp(c->errstr, "Unix socket path too long") == 0);
+        valkeyFree(c);
+    }
 #endif
 }
 


### PR DESCRIPTION
Previously, paths longer than sun_path (108 bytes on Linux) were silently truncated via strncpy, potentially connecting to the wrong socket.

Now returns an error if the path doesn't fit. Also switched to vk_calloc to ensure the sockaddr_un is zero-initialized.