### PR TITLE
Fix async command timeout never firing under continuous writes

### DIFF
--- a/include/valkey/adapters/libevent.h
+++ b/include/valkey/adapters/libevent.h
@@ -42,6 +42,7 @@
 typedef struct valkeyLibeventEvents {
     valkeyAsyncContext *context;
     struct event *ev;
+    struct event *timer;
     struct event_base *base;
     struct timeval tv;
     short flags;
@@ -63,11 +64,6 @@ static void valkeyLibeventHandler(evutil_socket_t fd, short event, void *arg) {
         return;                               \
     }
 
-    if ((event & EV_TIMEOUT) && (e->state & VALKEY_LIBEVENT_DELETED) == 0) {
-        valkeyAsyncHandleTimeout(e->context);
-        CHECK_DELETED();
-    }
-
     if ((event & EV_READ) && e->context && (e->state & VALKEY_LIBEVENT_DELETED) == 0) {
         valkeyAsyncHandleRead(e->context);
         CHECK_DELETED();
@@ -82,9 +78,15 @@ static void valkeyLibeventHandler(evutil_socket_t fd, short event, void *arg) {
 #undef CHECK_DELETED
 }
 
+static void valkeyLibeventTimeoutHandler(evutil_socket_t fd, short event, void *arg) {
+    (void)fd;
+    (void)event;
+    valkeyLibeventEvents *e = (valkeyLibeventEvents *)arg;
+    valkeyAsyncHandleTimeout(e->context);
+}
+
 static void valkeyLibeventUpdate(void *privdata, short flag, int isRemove) {
     valkeyLibeventEvents *e = (valkeyLibeventEvents *)privdata;
-    const struct timeval *tv = e->tv.tv_sec || e->tv.tv_usec ? &e->tv : NULL;
 
     if (isRemove) {
         if ((e->flags & flag) == 0) {
@@ -103,7 +105,7 @@ static void valkeyLibeventUpdate(void *privdata, short flag, int isRemove) {
     event_del(e->ev);
     event_assign(e->ev, e->base, e->context->c.fd, e->flags | EV_PERSIST,
                  valkeyLibeventHandler, privdata);
-    event_add(e->ev, tv);
+    event_add(e->ev, NULL);
 }
 
 static void valkeyLibeventAddRead(void *privdata) {
@@ -130,6 +132,10 @@ static void valkeyLibeventCleanup(void *privdata) {
     event_del(e->ev);
     event_free(e->ev);
     e->ev = NULL;
+    if (e->timer) {
+        event_free(e->timer);
+        e->timer = NULL;
+    }
 
     if (e->state & VALKEY_LIBEVENT_ENTERED) {
         e->state |= VALKEY_LIBEVENT_DELETED;
@@ -140,10 +146,12 @@ static void valkeyLibeventCleanup(void *privdata) {
 
 static void valkeyLibeventSetTimeout(void *privdata, struct timeval tv) {
     valkeyLibeventEvents *e = (valkeyLibeventEvents *)privdata;
-    short flags = e->flags;
-    e->flags = 0;
-    e->tv = tv;
-    valkeyLibeventUpdate(e, flags, 0);
+    if (e->timer == NULL)
+        e->timer = evtimer_new(e->base, valkeyLibeventTimeoutHandler, e);
+    else
+        evtimer_del(e->timer);
+    if (tv.tv_sec || tv.tv_usec)
+        evtimer_add(e->timer, &tv);
 }
 
 static int valkeyLibeventAttach(valkeyAsyncContext *ac, struct event_base *base) {

--- a/include/valkey/async.h
+++ b/include/valkey/async.h
@@ -69,6 +69,8 @@ typedef void(valkeyDisconnectCallback)(const struct valkeyAsyncContext *, int st
 typedef void(valkeyConnectCallback)(struct valkeyAsyncContext *, int status);
 typedef void(valkeyTimerCallback)(void *timer, void *privdata);
 
+#define VALKEY_TIMEOUT_INACTIVE -1
+
 /* Context for an async connection to Valkey */
 typedef struct valkeyAsyncContext {
     /* Hold the regular context, so it can be realloc'ed. */
@@ -121,6 +123,10 @@ typedef struct valkeyAsyncContext {
 
     /* Any configured RESP3 PUSH handler */
     valkeyAsyncPushFn *push_cb;
+
+    /* Replies received since command timeout timer was started, or
+     * VALKEY_TIMEOUT_INACTIVE when no timer is scheduled. */
+    int timeout_reply_count;
 } valkeyAsyncContext;
 
 LIBVALKEY_API valkeyAsyncContext *valkeyAsyncConnectWithOptions(const valkeyOptions *options);

--- a/src/async.c
+++ b/src/async.c
@@ -152,6 +152,8 @@ static valkeyAsyncContext *valkeyAsyncInitialize(valkeyContext *c) {
     ac->sub.schannels = schannels;
     ac->sub.pending_unsubs = 0;
 
+    ac->timeout_reply_count = VALKEY_TIMEOUT_INACTIVE;
+
     return ac;
 oom:
     dictRelease(channels);
@@ -583,6 +585,10 @@ void valkeyProcessCallbacks(valkeyAsyncContext *ac) {
         if (valkeyIsPushReply(reply))
             c->flags |= VALKEY_SUPPORTS_PUSH;
 
+        /* Any data from the server means it's alive. */
+        if (ac->timeout_reply_count != VALKEY_TIMEOUT_INACTIVE)
+            ac->timeout_reply_count++;
+
         /* Send any non-subscribe related PUSH messages to our PUSH handler
          * while allowing subscribe related PUSH messages to pass through.
          * This allows existing code to be backward compatible and work in
@@ -780,12 +786,21 @@ void valkeyAsyncHandleTimeout(valkeyAsyncContext *ac) {
     if ((c->flags & VALKEY_CONNECTED)) {
         if (ac->replies.head == NULL && ac->sub.replies.head == NULL) {
             /* Nothing to do - just an idle timeout */
+            ac->timeout_reply_count = VALKEY_TIMEOUT_INACTIVE;
             return;
         }
 
         if (!ac->c.command_timeout ||
             (!ac->c.command_timeout->tv_sec && !ac->c.command_timeout->tv_usec)) {
             /* A belated connect timeout arriving, ignore */
+            return;
+        }
+
+        /* If replies were received since the timer started, the server is
+         * alive. Restart the timer rather than timing out. */
+        if (ac->timeout_reply_count > 0) {
+            ac->timeout_reply_count = VALKEY_TIMEOUT_INACTIVE;
+            refreshTimeout(ac);
             return;
         }
     }

--- a/src/async_private.h
+++ b/src/async_private.h
@@ -66,15 +66,19 @@ static inline void refreshTimeout(valkeyAsyncContext *ctx) {
 #define VALKEY_TIMER_ISSET(tvp) \
     (tvp && ((tvp)->tv_sec || (tvp)->tv_usec))
 
-#define VALKEY_EL_TIMER(ac, tvp)                             \
-    if ((ac)->ev.scheduleTimer && VALKEY_TIMER_ISSET(tvp)) { \
-        (ac)->ev.scheduleTimer((ac)->ev.data, *(tvp));       \
-    }
-
     if (ctx->c.flags & VALKEY_CONNECTED) {
-        VALKEY_EL_TIMER(ctx, ctx->c.command_timeout);
+        /* Don't reset the timer if already active, prevents the timeout from
+         * never firing when commands are written continuously. */
+        if (ctx->timeout_reply_count != VALKEY_TIMEOUT_INACTIVE)
+            return;
+        if (ctx->ev.scheduleTimer && VALKEY_TIMER_ISSET(ctx->c.command_timeout)) {
+            ctx->ev.scheduleTimer(ctx->ev.data, *ctx->c.command_timeout);
+            ctx->timeout_reply_count = 0;
+        }
     } else {
-        VALKEY_EL_TIMER(ctx, ctx->c.connect_timeout);
+        if (ctx->ev.scheduleTimer && VALKEY_TIMER_ISSET(ctx->c.connect_timeout)) {
+            ctx->ev.scheduleTimer(ctx->ev.data, *ctx->c.connect_timeout);
+        }
     }
 }
 

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -2209,12 +2209,123 @@ void subscribe_with_timeout_cb(valkeyAsyncContext *ac, void *r, void *privdata) 
         state->checkpoint++;
 
         /* Send a command that will trigger a timeout */
-        valkeyAsyncCommand(ac, null_cb, state, "DEBUG SLEEP 3");
+        valkeyAsyncCommand(ac, null_cb, state, "DEBUG SLEEP 5");
         valkeyAsyncCommand(ac, null_cb, state, "LPUSH mylist foo");
     } else {
         printf("Unexpected pubsub command: %s\n", reply->element[0]->str);
         exit(1);
     }
+}
+
+static void async_ping_pong_cb(valkeyAsyncContext *ac, void *reply, void *privdata) {
+    int *count = (int *)privdata;
+    valkeyReply *r = reply;
+    assert(r != NULL && r->type == VALKEY_REPLY_STATUS);
+    assert(strcmp(r->str, "PONG") == 0);
+    (*count)++;
+    if (*count == 3) {
+        valkeyAsyncDisconnect(ac);
+        event_base_loopbreak(base);
+    }
+}
+
+static void test_command_timeout_not_fired_on_reply(struct config config) {
+    test("Command timeout does not fire when server responds: ");
+    base = event_base_new();
+    struct event *timeout = evtimer_new(base, timeout_cb, NULL);
+    struct timeval timeout_tv = {.tv_sec = 10};
+    evtimer_add(timeout, &timeout_tv);
+
+    valkeyOptions options = get_server_tcp_options(config);
+    valkeyAsyncContext *ac = valkeyAsyncConnectWithOptions(&options);
+    assert(ac != NULL && ac->err == 0);
+    valkeyLibeventAttach(ac, base);
+
+    struct timeval command_timeout = {.tv_sec = 1};
+    valkeyAsyncSetTimeout(ac, command_timeout);
+
+    /* Send multiple commands, server will reply to all of them quickly. */
+    int count = 0;
+    valkeyAsyncCommand(ac, async_ping_pong_cb, &count, "PING");
+    valkeyAsyncCommand(ac, async_ping_pong_cb, &count, "PING");
+    valkeyAsyncCommand(ac, async_ping_pong_cb, &count, "PING");
+
+    event_base_dispatch(base);
+    event_free(timeout);
+    event_base_free(base);
+
+    /* All 3 replies received, no timeout. */
+    test_cond(count == 3);
+}
+
+struct continuous_write_state {
+    valkeyAsyncContext *ac;
+    struct event *write_ev;
+    int timed_out;
+};
+
+static void write_timer_cb(evutil_socket_t fd, short event, void *arg) {
+    (void)fd;
+    (void)event;
+    struct continuous_write_state *state = arg;
+    /* Send a command every tick, previously this would reset the timeout. */
+    valkeyAsyncCommand(state->ac, NULL, NULL, "PING");
+}
+
+static void continuous_timeout_cb(valkeyAsyncContext *ac, void *reply, void *privdata) {
+    (void)ac;
+    struct continuous_write_state *state = privdata;
+    if (reply == NULL) {
+        state->timed_out = 1;
+        event_del(state->write_ev);
+        event_base_loopbreak(base);
+    }
+}
+
+static void test_command_timeout_with_continuous_writes(struct config config) {
+    test("Command timeout fires despite continuous writes: ");
+
+    /* This test requires DEBUG SLEEP which may not be available. */
+    valkeyContext *c = valkeyConnect(config.tcp.host, config.tcp.port);
+    assert(c != NULL);
+    if (!detect_debug_sleep(c)) {
+        valkeyFree(c);
+        test_skipped();
+        return;
+    }
+    valkeyFree(c);
+
+    base = event_base_new();
+    struct event *timeout = evtimer_new(base, timeout_cb, NULL);
+    struct timeval timeout_tv = {.tv_sec = 10};
+    evtimer_add(timeout, &timeout_tv);
+
+    valkeyOptions options = get_server_tcp_options(config);
+    valkeyAsyncContext *ac = valkeyAsyncConnectWithOptions(&options);
+    assert(ac != NULL && ac->err == 0);
+    valkeyLibeventAttach(ac, base);
+
+    struct timeval command_timeout = {.tv_sec = 1};
+    valkeyAsyncSetTimeout(ac, command_timeout);
+
+    /* DEBUG SLEEP blocks the server for 3s. Our timeout is 1s. */
+    valkeyAsyncCommand(ac, NULL, NULL, "DEBUG SLEEP 3");
+
+    struct continuous_write_state state = {.ac = ac, .timed_out = 0};
+
+    /* Write a command every 200ms, this used to reset the timer each time. */
+    state.write_ev = event_new(base, -1, EV_PERSIST, write_timer_cb, &state);
+    struct timeval write_interval = {.tv_sec = 0, .tv_usec = 200000};
+    event_add(state.write_ev, &write_interval);
+
+    valkeyAsyncCommand(ac, continuous_timeout_cb, &state, "PING");
+
+    event_base_dispatch(base);
+    event_free(state.write_ev);
+    event_free(timeout);
+    event_base_free(base);
+
+    test_cond(state.timed_out == 1);
 }
 
 static void test_command_timeout_during_pubsub(struct config config) {
@@ -2893,6 +3004,8 @@ int main(int argc, char **argv) {
         test_pubsub_handling_resp3(cfg);
         test_command_timeout_during_pubsub(cfg);
     }
+    test_command_timeout_not_fired_on_reply(cfg);
+    test_command_timeout_with_continuous_writes(cfg);
 
     if (enable_cluster_tests) {
         sharded_pubsub_test(cfg);


### PR DESCRIPTION
The command timeout timer was reset on every write, so continuously sending commands to an unresponsive server would prevent the timeout from ever firing.
    
Fixed by not resetting the timer if its is already active. When the timer fires, check if any replies (including push messages) were received since it started. If yes, the server is alive and the timer restarts. If no, it's a real timeout and the connection is closed.

Additional issue in the `libevent` adapter (used in test):
The timeout was combined with the I/O event in a single struct event. With the needed `EV_PERSIST`, libevent resets the timeout on every I/O callback. Even if the library didn't reschedule, any read/write activity silently restarted the timer.

