### PR TITLE
Add `maxdepth` member to `valkeyReader`.

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -17,6 +17,7 @@ This document describes using `libvalkey` in standalone (non-cluster) mode, incl
   - [Reader configuration](#reader-configuration)
     - [Input buffer size](#maximum-input-buffer-size)
     - [Maximum array elements](#maximum-array-elements)
+    - [Maximum reply nesting depth](#maximum-reply-nesting-depth)
     - [RESP3 Push Replies](#resp3-push-replies)
     - [Allocator injection](#allocator-injection)
 - [Asynchronous API](#asynchronous-api)
@@ -238,6 +239,14 @@ By default, libvalkey will refuse to parse array-like replies if they have more 
 
 ```c
 context->reader->maxelements = 0;
+```
+
+#### Maximum reply nesting depth
+
+By default, the libvalkey reply parser limits nested aggregate replies to a depth of `VALKEY_READER_MAX_REPLY_DEPTH` (currently 1024). If you need to process replies nested more deeply, you can increase the value or set it to zero, meaning unlimited.
+
+```c
+context->reader->maxdepth = 0;
 ```
 
 #### RESP3 Push Replies

--- a/include/valkey/read.h
+++ b/include/valkey/read.h
@@ -70,6 +70,9 @@
 /* Default multi-bulk element limit */
 #define VALKEY_READER_MAX_ARRAY_ELEMENTS ((1LL << 32) - 1)
 
+/* Default maximum depth of nested aggregate replies. */
+#define VALKEY_READER_MAX_REPLY_DEPTH 1024
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -102,6 +105,7 @@ typedef struct valkeyReader {
     size_t len;            /* Buffer length */
     size_t maxbuf;         /* Max length of unused buffer */
     long long maxelements; /* Max multi-bulk elements */
+    int maxdepth;          /* Max nested aggregate reply depth */
 
     valkeyReadTask **task;
     int tasks;

--- a/src/read.c
+++ b/src/read.c
@@ -517,6 +517,12 @@ static int processAggregateItem(valkeyReader *r) {
     long long elements;
     int root = 0, len;
 
+    if (r->maxdepth > 0 && r->ridx >= r->maxdepth) {
+        valkeyReaderSetError(r, VALKEY_ERR_PROTOCOL,
+                             "Max nesting depth exceeded");
+        return VALKEY_ERR;
+    }
+
     if (r->ridx == r->tasks - 1) {
         if (valkeyReaderGrow(r) == VALKEY_ERR)
             return VALKEY_ERR;
@@ -713,6 +719,7 @@ valkeyReader *valkeyReaderCreateWithFunctions(valkeyReplyObjectFunctions *fn) {
     r->fn = fn;
     r->maxbuf = VALKEY_READER_MAX_BUF;
     r->maxelements = VALKEY_READER_MAX_ARRAY_ELEMENTS;
+    r->maxdepth = VALKEY_READER_MAX_REPLY_DEPTH;
     r->ridx = -1;
 
     return r;

--- a/tests/client_test.c
+++ b/tests/client_test.c
@@ -574,6 +574,46 @@ static void test_reply_reader(void) {
     freeReplyObject(root);
     valkeyReaderFree(reader);
 
+    test("Reader sets a default maximum nesting depth: ");
+    reader = valkeyReaderCreate();
+    test_cond(reader->maxdepth == VALKEY_READER_MAX_REPLY_DEPTH);
+    valkeyReaderFree(reader);
+
+    test("Can parse a reply at the maximum nesting depth: ");
+    reader = valkeyReaderCreate();
+    reader->fn = NULL;
+    for (i = 0; i < VALKEY_READER_MAX_REPLY_DEPTH; i++) {
+        valkeyReaderFeed(reader, (char *)"*1\r\n", 4);
+    }
+    valkeyReaderFeed(reader, (char *)"+OK\r\n", 5);
+    ret = valkeyReaderGetReply(reader, &reply);
+    test_cond(ret == VALKEY_OK && reply == (void *)VALKEY_REPLY_ARRAY);
+    valkeyReaderFree(reader);
+
+    test("Set error when nesting depth exceeds the configured maximum: ");
+    reader = valkeyReaderCreate();
+    for (i = 0; i <= VALKEY_READER_MAX_REPLY_DEPTH; i++) {
+        valkeyReaderFeed(reader, (char *)"*1\r\n", 4);
+    }
+    valkeyReaderFeed(reader, (char *)"+OK\r\n", 5);
+    ret = valkeyReaderGetReply(reader, &reply);
+    test_cond(ret == VALKEY_ERR &&
+              strcasecmp(reader->errstr, "Max nesting depth exceeded") == 0);
+    freeReplyObject(reply);
+    valkeyReaderFree(reader);
+
+    test("Can disable the maximum nesting depth: ");
+    reader = valkeyReaderCreate();
+    reader->maxdepth = 0;
+    reader->fn = NULL;
+    for (i = 0; i <= VALKEY_READER_MAX_REPLY_DEPTH; i++) {
+        valkeyReaderFeed(reader, (char *)"*1\r\n", 4);
+    }
+    valkeyReaderFeed(reader, (char *)"+OK\r\n", 5);
+    ret = valkeyReaderGetReply(reader, &reply);
+    test_cond(ret == VALKEY_OK && reply == (void *)VALKEY_REPLY_ARRAY);
+    valkeyReaderFree(reader);
+
     test("Correctly parses LLONG_MAX: ");
     reader = valkeyReaderCreate();
     valkeyReaderFeed(reader, ":9223372036854775807\r\n", 22);


### PR DESCRIPTION
Currently malicious `RESP` protocol data consisting of an extremely nested reply can cause a stack overflow in the `valkeyReader` parsing logic.

This commit simply adds a new member `maxdepth` which is very similar to the existing `maxelements` member. By default it limits the maximum nesting of `RESP` replies to 1024 which should be much higher than normal payloads reach while being far below the stack overflow risk.