### PR TITLE
Fix potential signed overflow plus better Windows function

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -47,6 +47,7 @@
 #include <limits.h>
 #include <poll.h>
 #include <pthread.h>
+#include <stdint.h>
 #include <time.h>
 
 /* Default DNS timeout when no connect_timeout is set (5 seconds). */
@@ -62,10 +63,10 @@ static void valkeyCaresLibraryInit(void) {
     ares_library_init(ARES_LIB_INIT_NONE);
 }
 
-static long valkeyDnsPollMillis(void) {
+static uint64_t valkeyDnsPollMillis(void) {
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
-    return (now.tv_sec * 1000) + now.tv_nsec / 1000000;
+    return ((uint64_t)now.tv_sec * 1000) + now.tv_nsec / 1000000;
 }
 
 /* Callback state for synchronous ares_getaddrinfo. */
@@ -189,19 +190,20 @@ static int caresStatusToEai(int status) {
     }
 }
 
-/* Drive c-ares poll loop until res->done or deadline exceeded. */
+/* Drive c-ares poll loop until res->done or timeout_ms has elapsed since
+ * start.  timeout_ms is in (0, INT_MAX). */
 static void caresPollLoop(ares_channel_t *channel, struct caresSockState *st,
-                          struct caresResult *res, long deadline) {
+                          struct caresResult *res, uint64_t start, long timeout_ms) {
     while (!res->done) {
         if (st->nfds == 0)
             break;
 
-        long now = valkeyDnsPollMillis();
-        long remaining = deadline - now;
-        if (remaining <= 0) {
+        uint64_t elapsed = valkeyDnsPollMillis() - start;
+        if (elapsed >= (uint64_t)timeout_ms) {
             ares_cancel(channel);
             break;
         }
+        long remaining = timeout_ms - (long)elapsed;
 
         struct timeval maxtv, tv;
         maxtv.tv_sec = remaining / 1000;
@@ -272,8 +274,8 @@ static int valkeyResolveCares(const char *host, int port, int flags,
 
     ares_getaddrinfo(channel, host, portstr, &hints, caresCallback, &res);
 
-    long deadline = valkeyDnsPollMillis() + effective_timeout;
-    caresPollLoop(channel, &sockstate, &res, deadline);
+    uint64_t start = valkeyDnsPollMillis();
+    caresPollLoop(channel, &sockstate, &res, start, effective_timeout);
 
     rv = EAI_FAIL;
     if (res.done && res.status == ARES_SUCCESS && res.ai) {
@@ -295,8 +297,8 @@ static int valkeyResolveCares(const char *host, int port, int flags,
         res.status = 0;
 
         ares_getaddrinfo(channel, host, portstr, &hints, caresCallback, &res);
-        deadline = valkeyDnsPollMillis() + effective_timeout;
-        caresPollLoop(channel, &sockstate, &res, deadline);
+        start = valkeyDnsPollMillis();
+        caresPollLoop(channel, &sockstate, &res, start, effective_timeout);
 
         if (res.done && res.status == ARES_SUCCESS && res.ai) {
             if (caresAddrInfoToAddrInfo(res.ai, result) == 0)

--- a/src/net.c
+++ b/src/net.c
@@ -242,21 +242,19 @@ int valkeyContextSetTcpUserTimeout(valkeyContext *c, unsigned int timeout) {
     return VALKEY_OK;
 }
 
-static long valkeyPollMillis(void) {
-#ifndef _MSC_VER
+static uint64_t valkeyPollMillis(void) {
+#ifndef _WIN32
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
-    return (now.tv_sec * 1000) + now.tv_nsec / 1000000;
+    return ((uint64_t)now.tv_sec * 1000) + now.tv_nsec / 1000000;
 #else
-    FILETIME ft;
-    GetSystemTimeAsFileTime(&ft);
-    return (((long long)ft.dwHighDateTime << 32) | ft.dwLowDateTime) / 10;
+    return GetTickCount64();
 #endif
 }
 
 static int valkeyContextWaitReady(valkeyContext *c, long msec) {
     struct pollfd wfd;
-    long end;
+    uint64_t start;
     int res;
 
     if (errno != EINPROGRESS) {
@@ -267,14 +265,15 @@ static int valkeyContextWaitReady(valkeyContext *c, long msec) {
 
     wfd.fd = c->fd;
     wfd.events = POLLOUT;
-    end = msec >= 0 ? valkeyPollMillis() + msec : 0;
+    start = msec >= 0 ? valkeyPollMillis() : 0;
 
     while ((res = poll(&wfd, 1, msec)) <= 0) {
         if (res < 0 && errno != EINTR) {
             valkeySetErrorFromErrno(c, VALKEY_ERR_IO, "poll(2)");
             valkeyNetClose(c);
             return VALKEY_ERR;
-        } else if (res == 0 || (msec >= 0 && valkeyPollMillis() >= end)) {
+        } else if (res == 0 ||
+                   (msec >= 0 && valkeyPollMillis() - start >= (uint64_t)msec)) {
             errno = ETIMEDOUT;
             valkeySetErrorFromErrno(c, VALKEY_ERR_IO, NULL);
             valkeyNetClose(c);

--- a/src/sockcompat.c
+++ b/src/sockcompat.c
@@ -258,7 +258,7 @@ int win32_setsockopt(SOCKET sockfd, int level, int optname, const void *optval, 
         const struct timeval *tv = optval;
         DWORD timeout;
         uint64_t timeout_msec;
-        if (tv->tv_sec < 0 || tv->tv_usec < 0 || tv->tv_usec > 1000000) {
+        if (tv->tv_sec < 0 || tv->tv_usec < 0 || tv->tv_usec >= 1000000) {
             errno = EINVAL;
             return -1;
         }

--- a/src/sockcompat.c
+++ b/src/sockcompat.c
@@ -259,11 +259,13 @@ int win32_setsockopt(SOCKET sockfd, int level, int optname, const void *optval, 
         DWORD timeout;
         uint64_t timeout_msec;
         if (tv->tv_sec < 0 || tv->tv_usec < 0 || tv->tv_usec >= 1000000) {
+            WSASetLastError(WSAEINVAL);
             errno = EINVAL;
             return -1;
         }
         timeout_msec = (uint64_t)tv->tv_sec * 1000 + (uint64_t)tv->tv_usec / 1000;
         if (timeout_msec > MAXDWORD) {
+            WSASetLastError(WSAEINVAL);
             errno = EINVAL;
             return -1;
         }

--- a/src/sockcompat.c
+++ b/src/sockcompat.c
@@ -32,6 +32,8 @@
 #include "sockcompat.h"
 
 #ifdef _WIN32
+#include <stdint.h>
+
 static int _wsaErrorToErrno(int err) {
     switch (err) {
     case WSAEWOULDBLOCK:
@@ -230,7 +232,7 @@ int win32_getsockopt(SOCKET sockfd, int level, int optname, void *optval, sockle
             socklen_t dwlen = 0;
             ret = getsockopt(sockfd, level, optname, (char *)&timeout, &dwlen);
             tv->tv_sec = timeout / 1000;
-            tv->tv_usec = (timeout * 1000) % 1000000;
+            tv->tv_usec = (timeout % 1000) * 1000;
         } else {
             ret = WSAEFAULT;
         }
@@ -254,8 +256,19 @@ int win32_setsockopt(SOCKET sockfd, int level, int optname, const void *optval, 
     int ret = 0;
     if ((level == SOL_SOCKET) && ((optname == SO_RCVTIMEO) || (optname == SO_SNDTIMEO))) {
         const struct timeval *tv = optval;
-        DWORD timeout = tv->tv_sec * 1000 + tv->tv_usec / 1000;
-        ret = setsockopt(sockfd, level, optname, (const char *)&timeout, sizeof(DWORD));
+        DWORD timeout;
+        uint64_t timeout_msec;
+        if (tv->tv_sec < 0 || tv->tv_usec < 0 || tv->tv_usec > 1000000) {
+            errno = EINVAL;
+            return -1;
+        }
+        timeout_msec = (uint64_t)tv->tv_sec * 1000 + (uint64_t)tv->tv_usec / 1000;
+        if (timeout_msec > MAXDWORD) {
+            errno = EINVAL;
+            return -1;
+        }
+        timeout = timeout_msec;
+        ret = setsockopt(sockfd, level, optname, (const char *)&timeout, sizeof(timeout));
     } else {
         ret = setsockopt(sockfd, level, optname, (const char *)optval, optlen);
     }

--- a/src/valkey_private.h
+++ b/src/valkey_private.h
@@ -52,7 +52,8 @@ static inline int valkeyContextTimeoutMsec(const struct timeval *timeout, long *
 
     /* Only use timeout when not NULL. */
     if (timeout != NULL) {
-        if (timeout->tv_usec > 1000000 || timeout->tv_sec > max_msec) {
+        if (timeout->tv_sec < 0 || timeout->tv_sec > max_msec || timeout->tv_usec < 0 ||
+            timeout->tv_usec >= 1000000) {
             *result = msec;
             return VALKEY_ERR;
         }


### PR DESCRIPTION
* Fixed potential signed overflow in `valkeyPollMillis()` and `valkeyDnsPollMillis()`
* Use `GetTicksCount64` on windows since it directly gives us elapsed milliseconds since boot.
* Fix an off-by-one calculation when guarding against invalid timeouts